### PR TITLE
Fix PEP 508 dependency operator: `=>` -> `>=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "sounddevice<1",
     "numpy>=2,<3",
     "pymicro-features==1.0.0",
-    "python-mpv=>1,<2",
+    "python-mpv>=1,<2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Fixes build failure caused by invalid `PEP 508` dependency syntax in `pyproject.toml`.

## Details
The dependency string `python-mpv=>1,<2` uses invalid syntax (using `=>` instead of `>=`). This caused the build to fail with:

```log
+ python -m build --wheel --outdir /opt/wheels

...

ValueError: invalid pyproject.toml config: `project.dependencies[4]`.
configuration error: `project.dependencies[4]` must be pep508
```

## Testing
- Verified build completes successfully with `python -m build --wheel`
- All other dependencies remain unchanged
- Build artifacts are valid wheels

## Checklist
- [x] Fix does not change application functionality
- [x] Only modifies `pyproject.toml`
- [x] Maintains original dependency constraints