### PR TITLE
Command line switches

### DIFF
--- a/script/run
+++ b/script/run
@@ -14,4 +14,5 @@ if _VENV_DIR.exists():
 else:
     python_exe = "python3"
 
-subprocess.check_call([python_exe, "-m", "linux_voice_assistant"] + sys.argv[1:])
+result = subprocess.run([python_exe, "-m", "linux_voice_assistant"] + sys.argv[1:])
+sys.exit(result.returncode)


### PR DESCRIPTION
* Cleaned up the --help output

* Made the --name command-line option optional so audio device listings can run without it, while still enforcing the requirement for normal operation.

* Added a pre-parse check to display the CLI help message and exit cleanly when the program is run without any arguments.

* Updated the --name argument help text to clarify that the voice assistant name is required for normal operation.

* Updated script/run to use subprocess.run and exit with the child return code, preventing tracebacks when argparse reports command-line errors this removed a bunch of "scary" error messages caused from improperly used command line arguments. For example, starting the server with no command line argument returns the "help" menu similar to running `script/start --help`.

* Added errno handling and wrapped the server binding in a try/except block to print a concise host/port error message instead of an asyncio traceback when the socket is unavailable.

* Deferred audio processing thread startup until after the server binds successfully, ensuring command line errors exit cleanly without hanging.