### PR TITLE
Add support for running commands on stt start and stop

### DIFF
--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -132,6 +132,18 @@ async def main() -> None:
         help="Enable thinking sound on startup",
     )
     parser.add_argument(
+        "--stt-start-command",
+        default=None,
+        type=str,
+        help="Command to run when the user starts speaking",
+    )
+    parser.add_argument(
+        "--stt-stop-command",
+        default=None,
+        type=str,
+        help="Command to run when the user stops speaking",
+    )
+    parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
     args = parser.parse_args()
@@ -308,6 +320,8 @@ async def main() -> None:
         preferences_path=preferences_path,
         refractory_seconds=args.refractory_seconds,
         download_dir=args.download_dir,
+        stt_start_command=args.stt_start_command,
+        stt_stop_command=args.stt_stop_command,
     )
 
     if args.enable_thinking_sound:

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -92,6 +92,8 @@ class ServerState:
     thinking_sound_enabled: bool = False
     muted: bool = False
     connected: bool = False
+    stt_start_command: Optional[str] = None
+    stt_stop_command: Optional[str] = None
 
     def save_preferences(self) -> None:
         """Save preferences as JSON."""

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -47,7 +47,7 @@ from pyopen_wakeword import OpenWakeWord
 from .api_server import APIServer
 from .entity import MediaPlayerEntity, MuteSwitchEntity, ThinkingSoundEntity
 from .models import AvailableWakeWord, ServerState, WakeWordType
-from .util import call_all
+from .util import call_all, run_command
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -227,11 +227,15 @@ class VoiceSatelliteProtocol(APIServer):
                 self._processing = True
                 self.duck()
                 self.state.tts_player.play(self.state.processing_sound)
+        elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_START:
+            run_command(self.state.stt_start_command)
         elif event_type in (
             VoiceAssistantEventType.VOICE_ASSISTANT_STT_VAD_END,
             VoiceAssistantEventType.VOICE_ASSISTANT_STT_END,
         ):
             self._is_streaming_audio = False
+            if event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_END:
+                run_command(self.state.stt_stop_command)
         elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_INTENT_PROGRESS:
             if data.get("tts_start_streaming") == "1":
                 # Start streaming early

--- a/linux_voice_assistant/util.py
+++ b/linux_voice_assistant/util.py
@@ -1,10 +1,14 @@
 """Utility methods."""
 
+import logging
+import subprocess
 import uuid
 # netifaces lib is from netifaces2
 import netifaces
 from collections.abc import Callable
 from typing import Optional
+
+_LOGGER = logging.getLogger(__name__)
 
 def call_all(*callables: Optional[Callable[[], None]]) -> None:
     for item in filter(None, callables):
@@ -42,3 +46,12 @@ def get_default_ipv4(interface: str):
         return None
 
     return ipv4_info[0]["addr"]
+
+
+def run_command(command: Optional[str]) -> None:
+    if not command:
+        return
+
+    _LOGGER.debug("Running %s", command)
+
+    subprocess.call(command, shell=True)


### PR DESCRIPTION
This PR adds support for running commands on stt start and stop with the `--stt-start-command` and `--stt-stop-command` flags. This is useful for changing the audio input volume during stt, pausing music on a snapclient in the same device, turning device leds on and off, and so on.