### PR TITLE
Changes EXTRA_ARGS variable to bash array to better handle  variable expansion

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,37 +28,37 @@ TEMP_CLIENT_NAME="lva-${MAC}"
 
 ### Handlers
 # Handle parameters
-EXTRA_ARGS=""
+EXTRA_ARGS=()
 
 if [ "$ENABLE_DEBUG" = "1" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --debug"
+  EXTRA_ARGS+=( "--debug" )
 fi
 
 CLIENT_NAME=${CLIENT_NAME:-$TEMP_CLIENT_NAME}
 if [ -n "${CLIENT_NAME}" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --name $CLIENT_NAME"
+  EXTRA_ARGS+=( "--name" "$CLIENT_NAME" )
 fi
 
 PREFERENCES_FILE=${PREFERENCES_FILE:-"/app/configuration/preferences.json"}
 if [ -n "${PREFERENCES_FILE}" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --preferences-file $PREFERENCES_FILE"
+  EXTRA_ARGS+=( "--preferences-file" "$PREFERENCES_FILE" )
 fi
 
 PORT=${PORT:-6053}
 if [ -n "${PORT}" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --port $PORT"
+  EXTRA_ARGS+=( "--port" "$PORT" )
 fi
 
 if [ -n "${AUDIO_INPUT_DEVICE}" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --audio-input-device $AUDIO_INPUT_DEVICE"
+  EXTRA_ARGS+=( "--audio-input-device" "$AUDIO_INPUT_DEVICE" )
 fi
 
 if [ -n "${AUDIO_OUTPUT_DEVICE}" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --audio-output-device $AUDIO_OUTPUT_DEVICE"
+  EXTRA_ARGS+=( "--audio-output-device" "$AUDIO_OUTPUT_DEVICE" )
 fi
 
 if [ "$ENABLE_THINKING_SOUND" = "1" ]; then
-  EXTRA_ARGS="$EXTRA_ARGS --enable-thinking-sound"
+  EXTRA_ARGS+=( "--enable-thinking-sound" )
 fi
 
 
@@ -110,10 +110,10 @@ done
 ### Start application
 if [ "$LIST_DEVICES" = "1" ]; then
   echo "list input devices"
-  ./script/run "$@" $EXTRA_ARGS --list-input-devices
+  ./script/run "$@" "${EXTRA_ARGS[@]}" --list-input-devices
   echo "list output devices"
-  ./script/run "$@" $EXTRA_ARGS --list-output-devices
+  ./script/run "$@" "${EXTRA_ARGS[@]}" --list-output-devices
 else
   echo "starting application"
-  exec ./script/run "$@" $EXTRA_ARGS
+  exec ./script/run "$@" "${EXTRA_ARGS[@]}"
 fi


### PR DESCRIPTION
I ran into an issue when I tried to set my device name to something with a space in it, and the script wasn't able to handle that. This just adjusts the `EXTRA_ARGS` variable in the docker-entrypoint.sh file from a flat string to a Bash array to handle those variables with spaces in them. It may also be helpful in other circumstances too.

Thank you for your time and consideration!