### PR TITLE
Prevent wake word from interrupting active voice pipeline

### DIFF
--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -218,6 +218,7 @@ class VoiceSatelliteProtocol(APIServer):
             self._tts_url = data.get("url")
             self._tts_played = False
             self._continue_conversation = False
+            self._pipeline_active = True
         elif (
             event_type == VoiceAssistantEventType.VOICE_ASSISTANT_INTENT_START
             and self.state.thinking_sound_enabled


### PR DESCRIPTION
## Problem
After dismissing a timer, subsequent voice commands would fail. The wake word 
detector would false-trigger during active STT listening, aborting the pipeline 
and starting a new one that never received the user's speech.

## Root Cause
The `wakeup()` method had no check for whether a voice pipeline was already 
running. The `_pipeline_active` flag existed but was never set or checked.

## Fix
- Guard `wakeup()` with `_pipeline_active` to ignore wake words during an 
  active pipeline
- Set the flag to `True` when a pipeline starts
- Reset to `False` on `RUN_END`, in `stop()`, and in `_tts_finished()`

## Testing
Tested on a Raspberry Pi with Jabra SPEAK 510 USB. Reproduced the bug 
consistently (timer → stop → next command fails), confirmed the fix resolves it.