### PR TITLE
Bugfix: start listening after wakeup sound

### DIFF
--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -426,8 +426,12 @@ class VoiceSatelliteProtocol(APIServer):
             [VoiceAssistantRequest(start=True, wake_word_phrase=wake_word_phrase)]
         )
         self.duck()
+        self.state.tts_player.play(self.state.wakeup_sound, done_callback=self._on_wakeup_sound_finished)
+    
+    def _on_wakeup_sound_finished(self) -> None:
+        """Callback invoked when the wakeup sound finishes playing."""
         self._is_streaming_audio = True
-        self.state.tts_player.play(self.state.wakeup_sound)
+        _LOGGER.debug("Wakeup sound finished, starting audio streaming")
 
     def stop(self) -> None:
         self.state.active_wake_words.discard(self.state.stop_word.id)


### PR DESCRIPTION
By default the wakeup sound was played and the listening was started while not waiting for the sound playback to be finished. Now it will wait for that and then start listening.

Fixes: https://github.com/OHF-Voice/linux-voice-assistant/issues/170
Fixes: https://github.com/OHF-Voice/linux-voice-assistant/issues/157