### PR TITLE
Include linux_voice_assistant.player module in setuptools build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ zip-safe  = true
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["linux_voice_assistant"]
+include = ["linux_voice_assistant*"]
 exclude = ["tests", "tests.*"]
 
 [tool.black]


### PR DESCRIPTION
Without the wildcard at the end only the toplevel package will be included.

Long-term I would propose migrating to a src layout, which facilitates better autodiscovery properties.