### PR TITLE
Downgrade to Python 3.12 for quicker webrtc builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-trixie
+FROM python:3.12-slim-trixie
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
As webrtc-noise-gain does not have any 3.13 wheels we can downgrade to 3.12 for better build times and smaller images.