### PR TITLE
Enable setuptools-scm

### DIFF
--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Derive version information
         id: version
         run: |
-          echo "version=$(git describe --always | sed 's/^v//')-nightly" >> $GITHUB_OUTPUT
+          echo "version=$(git describe --tags | sed 's/^v//')-nightly" >> $GITHUB_OUTPUT
 
       - name: Create version files
         run: |

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Derive version information
+        id: version
+        run: |
+          echo "version=$(git describe --always | sed 's/^v//')-nightly" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "nightly" > version.txt
@@ -53,6 +58,9 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY_LOWER }}/${{ env.REPOSITORY_LOWER }}:nightly
           labels: "nightly"
+          build-args: |
+            VERSION=${{ setps.version.outputs.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1.4.4
         with:

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Derive version information
         id: version
         run: |
+          sudo apt update
+          sudo apt install git
           echo "version=$(script/version --suffix nightly)" >> $GITHUB_OUTPUT
 
       - name: Create version files

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Derive version information
         id: version
         run: |
-          echo "version=$(git describe --tags | sed 's/^v//')-nightly" >> $GITHUB_OUTPUT
+          echo "version=$(script/version --suffix nightly)" >> $GITHUB_OUTPUT
 
       - name: Create version files
         run: |

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Set lowercase registry and repository
         run: |
           echo "REGISTRY_LOWER=$(echo '${{ env.REGISTRY }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Derive version information
+        id: version
+        run: |
+          echo "version=$(git describe --always | sed 's/^v//')-nightly" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "nightly" > version.txt
@@ -53,6 +58,9 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY_LOWER }}/${{ env.REPOSITORY_LOWER }}:nightly
           labels: "nightly"
+          build-args: |
+            VERSION=${{ setps.version.outputs.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Derive version info
+        id: version
+        run: |
+          echo "version=$(git describe --tags | sed 's/^v//')-pr${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "${{ env.PR_NUMBER }}" > version.txt
@@ -58,6 +63,9 @@ jobs:
           push: true
           tags: "${{ env.REGISTRY_LOWER }}/${{ env.REPOSITORY_LOWER }}-pr:${{ env.PR_NUMBER }}"
           labels: "${{ env.PR_NUMBER }}"
+          build-args: |
+            VERSION=${{ steps.version.output.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1.4.4
         with:

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -50,6 +50,8 @@ jobs:
         env:
           SUFFIX: pr${{ ENV.PR_NUMBER }}
         run: |
+          sudo apt update
+          sudo apt install git
           echo "version=$(script/version)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -47,14 +47,10 @@ jobs:
 
       - name: Derive version info
         id: version
+        env:
+          SUFFIX: pr${{ ENV.PR_NUMBER }}
         run: |
-          echo "version=$(git describe --tags | sed 's/^v//')-pr${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
-
-      - name: Create version files
-        run: |
-          echo "${{ env.PR_NUMBER }}" > version.txt
-          echo "${{ github.sha }}" > version_githash.txt
-          ls -ltr
+          echo "version=$(script/version)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
+          fetch-depth: 0
 
       - name: Set variables
         run: |

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Derive version info
+        id: version
+        run: |
+          echo "version=$(git describe --tags | sed 's/^v//')-pr${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "${{ env.PR_NUMBER }}" > version.txt
@@ -59,6 +64,9 @@ jobs:
           push: true
           tags: "${{ env.REGISTRY_LOWER }}/${{ env.REPOSITORY_LOWER }}-pr:${{ env.PR_NUMBER }}"
           labels: "${{ env.PR_NUMBER }}"
+          build-args: |
+            VERSION=${{ steps.version.output.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Derive version information
         id: version
         run: |
-          echo "version=$(git describe --tag | sed 's/^v//')" >> $GITHUB_OUTPUT
+          echo "version=$(script/version)" >> $GITHUB_OUTPUT
 
       - name: Create version files
         run: |

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -46,6 +46,11 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
+      - name: Derive version information
+        id: version
+        run: |
+          echo "version=$(git describe --always | sed 's/^v//')" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "${{ steps.meta.outputs.version }}" > version.txt
@@ -61,6 +66,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ setps.version.outputs.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Derive version information
         id: version
         run: |
-          echo "version=$(git describe --always | sed 's/^v//')" >> $GITHUB_OUTPUT
+          echo "version=$(git describe --tag | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Create version files
         run: |

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Derive version information
         id: version
         run: |
+          sudo apt update
+          sudo apt install git
           echo "version=$(script/version)" >> $GITHUB_OUTPUT
 
       - name: Create version files

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -46,6 +46,11 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
+      - name: Derive version information
+        id: version
+        run: |
+          echo "version=$(git describe --always | sed 's/^v//')" >> $GITHUB_OUTPUT
+
       - name: Create version files
         run: |
           echo "${{ steps.meta.outputs.version }}" > version.txt
@@ -61,6 +66,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ setps.version.outputs.version }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
@@ -45,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
@@ -60,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
@@ -76,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
+ARG VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
 LABEL \
     org.opencontainers.image.authors="Open Home Foundation" \
     org.opencontainers.image.description="Voice assistant for Home Assistant" \

--- a/linux_voice_assistant/util.py
+++ b/linux_voice_assistant/util.py
@@ -14,14 +14,14 @@ _esphome_version_cache: Optional[str] = None
 
 def get_version() -> str:
     """
-    Read the version from version.txt file.
+    Read the version from dist-info metadata.
 
     This function reads the content safely without risk of code injection,
     as it only reads raw text and performs no evaluation.
 
     Returns:
-        str:    The version from version.txt or 'unknown' if the file
-                does not exist or cannot be read.
+        str:    The version from dist-info metadata or 'unknown' if no version
+                metadata can be found.
     """
     global _version_cache
 

--- a/linux_voice_assistant/util.py
+++ b/linux_voice_assistant/util.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
 from typing import Optional
 
 # netifaces lib is from netifaces2
@@ -29,13 +28,9 @@ def get_version() -> str:
     if _version_cache is not None:
         return _version_cache
 
-    version_file = Path(__file__).parent.parent / "version.txt"
-
     try:
-        # Sicher lesen: nur Rohtext, keine Evaluierung
-        file_version = version_file.read_text(encoding="utf-8").strip()
-        _version_cache = file_version if file_version else "unknown"
-    except (FileNotFoundError, PermissionError, OSError):
+        _version_cache = version("linux_voice_assistant")
+    except PackageNotFoundError:
         _version_cache = "unknown"
 
     return _version_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ include-package-data = true
 include = ["linux_voice_assistant", "linux_voice_assistant.*"]
 exclude = ["tests", "tests.*"]
 
+[tool.setuptools_scm]
+
 [tool.black]
 line-length = 200
 target-version = ['py312', 'py313']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ include-package-data = true
 include = ["linux_voice_assistant", "linux_voice_assistant.*"]
 exclude = ["tests", "tests.*"]
 
+[tool.setuptools_scm]
+
 [tool.black]
 line-length = 200
 target-version = ['py312', 'py313']

--- a/script/setup
+++ b/script/setup
@@ -27,6 +27,15 @@ if args.cxxflags:
 if args.makeflags:
     env["MAKEFLAGS"] = args.makeflags
 
+# Derive version information from Git
+try:
+    version = subprocess.check_output(["git", "describe", "--tags"]).decode()
+    version = version.lstrip("v")
+except (subprocess.CalledProcessError, FileNotFoundError):
+    version = "0.0.0"
+
+env["SETUPTOOLS_SCM_PRETEND_VERSION"] = version
+
 # Upgrade dependencies
 pip = [context.env_exe, "-m", "pip"]
 subprocess.check_call(pip + ["install", "--upgrade", "pip"])

--- a/script/setup
+++ b/script/setup
@@ -2,7 +2,6 @@
 import argparse
 import ctypes.util
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -67,24 +66,10 @@ if args.cxxflags:
 if args.makeflags:
     env["MAKEFLAGS"] = args.makeflags
 
-# Derive version information from Git
-
-try:
-    version = subprocess.check_output(
-        ["git", "describe", "--tags", "--long", "--always"], text=True
-    ).strip()
-    version = version.removeprefix("v")
-except (subprocess.CalledProcessError, FileNotFoundError):
-    version = "0.0.0"
-
-# Create PEP440 compatible version from Git describe
-if match := re.match(r"(.+)-(\d+)-g([0-9a-f]+)$", version):
-    tag, distance, hash = match.groups()
-    version = f"{tag}.post{distance}+g{hash}"
-
-print(f"Discovered version: {version}")
-
-env["SETUPTOOLS_SCM_PRETEND_VERSION"] = version
+env["SETUPTOOLS_SCM_PRETEND_VERSION"] = subprocess.check_output(
+    [_PROGRAM_DIR / "script" / "version"],
+    text=True,
+).strip()
 
 # Upgrade dependencies
 pip = [str(_VENV_DIR / "bin" / "python"), "-m", "pip"]

--- a/script/setup
+++ b/script/setup
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import argparse
-import subprocess
-import os
-import shutil
-import sys
 import ctypes.util
+import os
+import re
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 _DIR = Path(__file__).parent
@@ -67,11 +68,19 @@ if args.makeflags:
     env["MAKEFLAGS"] = args.makeflags
 
 # Derive version information from Git
+
 try:
-    version = subprocess.check_output(["git", "describe", "--tags"]).decode()
-    version = version.lstrip("v")
+    version = subprocess.check_output(
+        ["git", "describe", "--tags", "--long", "--always"], text=True
+    ).strip()
+    version = version.removeprefix("v")
 except (subprocess.CalledProcessError, FileNotFoundError):
     version = "0.0.0"
+
+# Create PEP440 compatible version from Git describe
+if match := re.match(r"(.+)-(\d+)-g([0-9a-f]+)$", version):
+    tag, distance, hash = match.groups()
+    version = f"{tag}.post{distance}+g{hash}"
 
 env["SETUPTOOLS_SCM_PRETEND_VERSION"] = version
 

--- a/script/setup
+++ b/script/setup
@@ -66,6 +66,15 @@ if args.cxxflags:
 if args.makeflags:
     env["MAKEFLAGS"] = args.makeflags
 
+# Derive version information from Git
+try:
+    version = subprocess.check_output(["git", "describe", "--tags"]).decode()
+    version = version.lstrip("v")
+except (subprocess.CalledProcessError, FileNotFoundError):
+    version = "0.0.0"
+
+env["SETUPTOOLS_SCM_PRETEND_VERSION"] = version
+
 # Upgrade dependencies
 pip = [str(_VENV_DIR / "bin" / "python"), "-m", "pip"]
 subprocess.check_call(pip + ["install", "--upgrade", "pip"])

--- a/script/setup
+++ b/script/setup
@@ -82,6 +82,8 @@ if match := re.match(r"(.+)-(\d+)-g([0-9a-f]+)$", version):
     tag, distance, hash = match.groups()
     version = f"{tag}.post{distance}+g{hash}"
 
+print(f"Discovered version: {version}")
+
 env["SETUPTOOLS_SCM_PRETEND_VERSION"] = version
 
 # Upgrade dependencies

--- a/script/version
+++ b/script/version
@@ -10,7 +10,7 @@ def get_git_describe() -> str:
         return subprocess.check_output(
             ["git", "describe", "--tags", "--long", "--always"], text=True
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return "0.0.0"
 
 

--- a/script/version
+++ b/script/version
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+import argparse
+import os
+import re
+import subprocess
+
+
+def get_git_describe() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "describe", "--tags", "--long", "--always"], text=True
+        )
+    except subprocess.CalledProcessError:
+        return "0.0.0"
+
+
+def to_pep440_version(version: str, suffix: str | None = None) -> str:
+    # Remove leading v from git tag
+    version = version.removeprefix("v")
+
+    # Remove leading and trailing whitespace
+    version = version.strip()
+
+    # Create PEP440 compatible version from Git describe
+    if match := re.match(r"(.+)-(\d+)-g([0-9a-f]+)$", version):
+        tag, distance, hash = match.groups()
+        version = f"{tag}.post{distance}+g{hash}"
+
+    if suffix:
+        version = version + f".{suffix}"
+
+    return version
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert git describe output to a PEP 440 version."
+    )
+    parser.add_argument(
+        "--suffix",
+        help="Optional version suffix to append.",
+        default=os.environ.get("SUFFIX")
+    )
+    args = parser.parse_args()
+
+    describe = get_git_describe()
+    pep440_version = to_pep440_version(describe, suffix=args.suffix)
+
+    print(pep440_version)
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -1,6 +1,5 @@
 """Unit tests for utility functions."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
@@ -15,71 +14,47 @@ class TestGetVersion:
 
         util._version_cache = None
 
-    def test_returns_unknown_when_file_missing(self):
+    def test_returns_package_version(self):
         import linux_voice_assistant.util as util
 
-        util._version_cache = None
-
-        with patch.object(Path, "read_text", side_effect=FileNotFoundError):
+        with patch.object(util, "version", return_value="1.2.3"):
             result = util.get_version()
-        assert result == "unknown"
 
-    def test_returns_version_string_from_file(self):
-        import linux_voice_assistant.util as util
-
-        util._version_cache = None
-
-        with patch.object(Path, "read_text", return_value="1.2.3\n"):
-            result = util.get_version()
         assert result == "1.2.3"
 
-    def test_strips_whitespace_from_version(self):
+    def test_returns_unknown_when_package_metadata_missing(self):
+        from importlib.metadata import PackageNotFoundError
+
         import linux_voice_assistant.util as util
 
-        util._version_cache = None
-
-        with patch.object(Path, "read_text", return_value="  2.0.0  \n"):
+        with patch.object(
+            util,
+            "version",
+            side_effect=PackageNotFoundError,
+        ):
             result = util.get_version()
-        assert result == "2.0.0"
 
-    def test_returns_unknown_for_empty_file(self):
-        import linux_voice_assistant.util as util
-
-        util._version_cache = None
-
-        with patch.object(Path, "read_text", return_value="   "):
-            result = util.get_version()
         assert result == "unknown"
 
     def test_caches_result_after_first_call(self):
         import linux_voice_assistant.util as util
 
-        util._version_cache = None
+        with patch.object(util, "version", return_value="3.0.0") as mock_version:
+            assert util.get_version() == "3.0.0"
+            assert util.get_version() == "3.0.0"
 
-        with patch.object(Path, "read_text", return_value="3.0.0") as mock_read:
-            util.get_version()
-            util.get_version()
-            mock_read.assert_called_once()
+        mock_version.assert_called_once()
 
     def test_returns_cached_value_on_second_call(self):
         import linux_voice_assistant.util as util
 
         util._version_cache = None
 
-        with patch.object(Path, "read_text", return_value="4.0.0"):
+        with patch.object(util, "version", return_value="4.0.0"):
             first = util.get_version()
 
         second = util.get_version()
         assert first == second == "4.0.0"
-
-    def test_returns_unknown_on_permission_error(self):
-        import linux_voice_assistant.util as util
-
-        util._version_cache = None
-
-        with patch.object(Path, "read_text", side_effect=PermissionError):
-            result = util.get_version()
-        assert result == "unknown"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the package version, since setuptools-scm needs to be enabled through the existence of its config section.

From

```
Successfully built linux_voice_assistant-0.0.0.tar.gz and linux_voice_assistant-0.0.0-py3-none-any.whl
```

To

```
Successfully built linux_voice_assistant-1.1.11.dev0+g73b494275.d19800101.tar.gz and linux_voice_assistant-1.1.11.dev0+g73b494275.d19800101-py3-none-any.whl
```

This requires further changes to the container builds, since they don't have a `.git` tree to pull the version info from. Instead, we use `git describe` at build time to come up with a version.

With that change applied the package version can be looked up from package metadata and `version.txt` is not required any longer.
