### PR TITLE
feat: Add state_file JSON exporting for external IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For all other users, we have different installation methods available (Docker, s
 ```sh
 usage: __main__.py [-h] [--name NAME] [--audio-input-device AUDIO_INPUT_DEVICE] [--list-input-devices] [--audio-input-block-size AUDIO_INPUT_BLOCK_SIZE] [--audio-output-device AUDIO_OUTPUT_DEVICE] [--list-output-devices] [--wake-word-dir WAKE_WORD_DIR]  [--mic-auto-gain] [--mic-noise-suppression]
                    [--wake-model WAKE_MODEL] [--stop-model STOP_MODEL] [--download-dir DOWNLOAD_DIR] [--refractory-seconds REFRACTORY_SECONDS] [--wakeup-sound WAKEUP_SOUND] [--timer-finished-sound TIMER_FINISHED_SOUND] [--processing-sound PROCESSING_SOUND]
-                   [--mute-sound MUTE_SOUND] [--unmute-sound UNMUTE_SOUND] [--preferences-file PREFERENCES_FILE] [--host HOST] [--network-interface NETWORK_INTERFACE] [--port PORT] [--enable-thinking-sound] [--debug]
+                   [--mute-sound MUTE_SOUND] [--unmute-sound UNMUTE_SOUND] [--preferences-file PREFERENCES_FILE] [--state-file STATE_FILE] [--host HOST] [--network-interface NETWORK_INTERFACE] [--port PORT] [--enable-thinking-sound] [--debug]
 ```
 
 
@@ -100,6 +100,7 @@ usage: __main__.py [-h] [--name NAME] [--audio-input-device AUDIO_INPUT_DEVICE] 
 | `--mute-sound`             | Sound played when muting the assistant                        | `sounds/mute_switch_on.flac`      |
 | `--unmute-sound`           | Sound played when unmuting the assistant                      | `sounds/mute_switch_off.flac`     |
 | `--preferences-file`       | Path to preferences JSON file                                 | `preferences.json`                |
+| `--state-file`             | Optional Path to conversation state JSON file                 | (disabled)                        |
 | `--host`                   | IP-Address for ESPHome server, use 0.0.0.0 for all            | Autodetected                      |
 | `--network-interface`      | Network interface for ESPHome server                          | Autodetected                      |
 | `--port`                   | Port for ESPHome server                                       | 6053                              |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,6 +18,10 @@ if [ -n "${PREFERENCES_FILE}" ]; then
   EXTRA_ARGS+=( "--preferences-file" "$PREFERENCES_FILE" )
 fi
 
+if [ -n "${STATE_FILE}" ]; then
+  EXTRA_ARGS+=( "--state-file" "$STATE_FILE" )
+fi
+
 if [ -n "${NETWORK_INTERFACE}" ]; then
   EXTRA_ARGS+=( "--network-interface" "$NETWORK_INTERFACE" )
 fi

--- a/docs/install_application.md
+++ b/docs/install_application.md
@@ -253,6 +253,7 @@ The following variables can be configured in the `.env` or in the service file:
 | `LVA_XDG_RUNTIME_DIR` | `/run/user/${LVA_USER_ID}` | XDG runtime directory |
 | `LVA_PULSE_COOKIE` | `/app/configuration/tmp_pulse_cookie` | Cookie file for PulseAudio if you use encryption. By default disabled. We use a tmp file to avoid errors if the file is not found |
 | `PREFERENCES_FILE` | (optional) | Path to a custom preferences JSON file |
+| `STATE_FILE` | (optional) | Optional Path to conversation state JSON file |
 | `NETWORK_INTERFACE` | Autodetected | network card for server |
 | `HOST` | Autodetected | API server IP-Address, can be 0.0.0.0 for all interfaces, but only one network card works for MAC-ADDRESS and ESP protocol |
 | `PORT` | `6053` | API server port |

--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -132,6 +132,10 @@ async def main() -> None:
         help="Directory and file name for the file where the preferences are stored in JSON format",
     )
     parser.add_argument(
+        "--state-file",
+        help="Optional path to write a JSON state file containing real-time conversation state.",
+    )
+    parser.add_argument(
         "--host",
         help="Optional host IP address to bind to (default: Autodetected by network interface)",  # 0.0.0.0 is IPv4, None is all interfaces
     )
@@ -321,6 +325,7 @@ async def main() -> None:
         unmute_sound=args.unmute_sound,
         preferences=preferences,
         preferences_path=preferences_path,
+        state_file=Path(args.state_file) if args.state_file else None,
         refractory_seconds=args.refractory_seconds,
         output_only=args.output_only,
         download_dir=args.download_dir,

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -99,6 +99,7 @@ class ServerState:
     preferences_path: Path
     download_dir: Path
 
+    state_file: Optional[Path] = None
     media_player_entity: "Optional[MediaPlayerEntity]" = None
     satellite: "Optional[VoiceSatelliteProtocol]" = None
     mute_switch_entity: "Optional[MuteSwitchEntity]" = None

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import hashlib
+import json
 import logging
 import posixpath
+from pathlib import Path
 import shutil
 import threading
 import time
@@ -72,6 +74,8 @@ class VoiceSatelliteProtocol(APIServer):
         self.state = state
         self.state.satellite = self
         self.state.connected = False
+
+        self._write_state("idle", clear_fields=True)
 
         # Report capabilities appropriately
         if state.output_only:
@@ -325,6 +329,49 @@ class VoiceSatelliteProtocol(APIServer):
         self._external_wake_words: Dict[str, VoiceAssistantExternalWakeWord] = {}
         self._disconnect_event = asyncio.Event()
 
+    def _write_state(
+        self,
+        status: str,
+        wake_word: Optional[str] = None,
+        stt_text: Optional[str] = None,
+        tts_text: Optional[str] = None,
+        clear_fields: bool = False,
+    ) -> None:
+        if not hasattr(self.state, "state_file") or not self.state.state_file:
+            return
+
+        if not hasattr(self, "_state_dict"):
+            self._state_dict = {
+                "timestamp": 0.0,
+                "status": "idle",
+                "wake_word": None,
+                "stt_text": None,
+                "tts_text": None,
+            }
+
+        self._state_dict["timestamp"] = time.time()
+        self._state_dict["status"] = status
+
+        if clear_fields:
+            self._state_dict["wake_word"] = None
+            self._state_dict["stt_text"] = None
+            self._state_dict["tts_text"] = None
+
+        if wake_word is not None:
+            self._state_dict["wake_word"] = wake_word
+        if stt_text is not None:
+            self._state_dict["stt_text"] = stt_text
+        if tts_text is not None:
+            self._state_dict["tts_text"] = tts_text
+
+        try:
+            temp_file = Path(self.state.state_file).with_suffix(".tmp")
+            with open(temp_file, "w", encoding="utf-8") as f:
+                json.dump(self._state_dict, f, ensure_ascii=False, indent=2)
+            temp_file.replace(self.state.state_file)
+        except Exception:
+            _LOGGER.exception("Failed to write LVA state to %s", self.state.state_file)
+
     def _set_thinking_sound_enabled(self, new_state: bool) -> None:
         self.state.thinking_sound_enabled = bool(new_state)
         self.state.preferences.thinking_sound = 1 if self.state.thinking_sound_enabled else 0
@@ -398,11 +445,13 @@ class VoiceSatelliteProtocol(APIServer):
                 self._processing = True
                 self.duck()
                 self.state.tts_player.play(self.state.processing_sound)
-        elif event_type in (
-            VoiceAssistantEventType.VOICE_ASSISTANT_STT_VAD_END,
-            VoiceAssistantEventType.VOICE_ASSISTANT_STT_END,
-        ):
+        elif event_type == getattr(VoiceAssistantEventType, "VOICE_ASSISTANT_STT_VAD_END", None) or event_type.name == "VOICE_ASSISTANT_STT_VAD_END":
             self._is_streaming_audio = False
+        elif event_type == getattr(VoiceAssistantEventType, "VOICE_ASSISTANT_STT_END", None) or event_type.name == "VOICE_ASSISTANT_STT_END":
+            self._is_streaming_audio = False
+            self._write_state("processing", stt_text=data.get("text"))
+        elif event_type.name == "VOICE_ASSISTANT_TTS_START":
+            self._write_state("responding", tts_text=data.get("text"))
         elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_INTENT_PROGRESS:
             if data.get("tts_start_streaming") == "1":
                 # Start streaming early
@@ -626,6 +675,7 @@ class VoiceSatelliteProtocol(APIServer):
             _LOGGER.debug("Stopping timer finished sound; will wake up in 1 s")
 
             wake_word_phrase = wake_word.wake_word  # type: ignore
+            self._write_state("listening", wake_word=wake_word_phrase, clear_fields=True)
 
             def _delayed_wakeup() -> None:
                 if self.state.muted or self._pipeline_active:
@@ -651,7 +701,9 @@ class VoiceSatelliteProtocol(APIServer):
             return
 
         wake_word_phrase = wake_word.wake_word  # type: ignore
-        _LOGGER.debug("Detected wake word: %s", wake_word_phrase)
+        self._write_state("listening", wake_word=wake_word_phrase, clear_fields=True)
+
+        _LOGGER.debug("Wakeup word detected: %s", wake_word_phrase)
         self._pipeline_active = True
         self.duck()
         self.state.tts_player.play(
@@ -668,6 +720,7 @@ class VoiceSatelliteProtocol(APIServer):
         self._is_streaming_audio = True
 
     def stop(self) -> None:
+        self._write_state("idle", clear_fields=True)
         self.state.active_wake_words.discard(self.state.stop_word.id)
         self._pipeline_active = False
 
@@ -710,9 +763,11 @@ class VoiceSatelliteProtocol(APIServer):
             self.send_messages([VoiceAssistantRequest(start=True)])
             self._is_streaming_audio = True
             self._pipeline_active = True
+            self._write_state("listening", clear_fields=True)
             _LOGGER.debug("Continuing conversation")
         else:
             self.unduck()
+            self._write_state("idle", clear_fields=True)
 
         _LOGGER.debug("TTS response finished")
 
@@ -749,6 +804,7 @@ class VoiceSatelliteProtocol(APIServer):
     def connection_lost(self, exc):
         super().connection_lost(exc)
 
+        self._write_state("idle", clear_fields=True)
         self._disconnect_event.set()
         self._is_streaming_audio = False
         self._tts_url = None


### PR DESCRIPTION
This pull request introduces the ability to export the current assistant state to a local JSON file in real-time. This is useful for external IPC (Inter-Process Communication) and third-party integrations (e.g., displaying the current state on a hardware LED matrix, sending notifications, or syncing with local dashboard panels).

To prevent partial or corrupted reads by external processes, the state is written to a temporary file (`.tmp`) and then atomically renamed to the target destination.

## Key Changes
* **CLI & Docker**:
  * Added `--state-file` command-line argument to specify the target JSON path.
  * Added support for `STATE_FILE` environment variable in [docker-entrypoint.sh](file:///home/dilli/src/linux-voice-assistant/docker-entrypoint.sh).
* **State Management**:
  * Added `state_file` attribute to `ServerState` in [linux_voice_assistant/models.py](file:///home/dilli/src/linux-voice-assistant/linux_voice_assistant/models.py).
  * Implemented `_write_state()` in `VoiceSatelliteProtocol` in [linux_voice_assistant/satellite.py](file:///home/dilli/src/linux-voice-assistant/linux_voice_assistant/satellite.py) to update and write the JSON file.
* **Transitions Tracked**:
  * `idle`: Clears the fields and resets the status.
  * `listening`: Triggered on wake-word detection (captures the detected `wake_word`).
  * `processing`: Triggered when Speech-to-Text (STT) finishes (captures the transcribed `stt_text`).
  * `responding`: Triggered when Text-to-Speech (TTS) starts (captures the spoken `tts_text`).
  * `connection_lost` / `stop`: Resets the state back to `idle`.