### PR TITLE
Add delay to continue conversation before listening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,9 @@ LVA_PULSE_COOKIE="/run/user/${LVA_USER_ID}/pulse/cookie"
 ### Refactory seconds (optional):
 # REFACTORY_SECONDS="2"
 
+### Delay before mic opens for continued conversation (optional):
+# CONTINUE_CONVERSATION_DELAY="0.5"
+
 ### Sound files (optional):
 # path for custom files in docker is for example "sounds/custom/your_soundfile.flac"
 # WAKEUP_SOUND="sounds/wake_word_triggered.flac"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -72,6 +72,10 @@ if [ -n "${REFACTORY_SECONDS}" ]; then
   EXTRA_ARGS+=( "--refractory-seconds" "$REFACTORY_SECONDS" )
 fi
 
+if [ -n "${CONTINUE_CONVERSATION_DELAY}" ]; then
+  EXTRA_ARGS+=( "--continue-conversation-delay" "$CONTINUE_CONVERSATION_DELAY" )
+fi
+
 if [ -n "${WAKEUP_SOUND}" ]; then
   EXTRA_ARGS+=( "--wakeup-sound" "$WAKEUP_SOUND" )
 fi

--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -322,6 +322,7 @@ async def main() -> None:
         preferences=preferences,
         preferences_path=preferences_path,
         refractory_seconds=args.refractory_seconds,
+        continue_conversation_delay=args.continue_conversation_delay,
         output_only=args.output_only,
         download_dir=args.download_dir,
         volume=initial_volume,

--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -106,7 +106,7 @@ async def main() -> None:
         type=float,
         default=0.5,
         help="Seconds to wait after TTS finishes before opening the mic for continued conversation (default: 0.5)",
-    )    
+    )
     parser.add_argument(
         "--wakeup-sound",
         default=str(_SOUNDS_DIR / "wake_word_triggered.flac"),

--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -102,6 +102,12 @@ async def main() -> None:
         help="Seconds before wake word can be activated again",
     )
     parser.add_argument(
+        "--continue-conversation-delay",
+        type=float,
+        default=0.5,
+        help="Seconds to wait after TTS finishes before opening the mic for continued conversation (default: 0.5)",
+    )    
+    parser.add_argument(
         "--wakeup-sound",
         default=str(_SOUNDS_DIR / "wake_word_triggered.flac"),
         help="Directory and file name for wake sound (when you say the wake word)",

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -98,6 +98,7 @@ class ServerState:
     preferences: Preferences
     preferences_path: Path
     download_dir: Path
+    continue_conversation_delay: float = 0.5   # seconds to wait after TTS before opening mic
 
     media_player_entity: "Optional[MediaPlayerEntity]" = None
     satellite: "Optional[VoiceSatelliteProtocol]" = None

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -98,7 +98,7 @@ class ServerState:
     preferences: Preferences
     preferences_path: Path
     download_dir: Path
-    continue_conversation_delay: float = 0.5   # seconds to wait after TTS before opening mic
+    continue_conversation_delay: float = 0.5  # seconds to wait after TTS before opening mic
 
     media_player_entity: "Optional[MediaPlayerEntity]" = None
     satellite: "Optional[VoiceSatelliteProtocol]" = None

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -712,7 +712,7 @@ class VoiceSatelliteProtocol(APIServer):
         self._pipeline_active = False
         self.state.active_wake_words.discard(self.state.stop_word.id)
         self.send_messages([VoiceAssistantAnnounceFinished()])
-    
+
         if self._continue_conversation:
             self._continue_conversation = False
             # Keep pipeline active during the settle delay so the mic stays closed

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -693,6 +693,35 @@ class VoiceSatelliteProtocol(APIServer):
         self.state.active_wake_words.add(self.state.stop_word.id)
         self.state.tts_player.play(self._tts_url, done_callback=self._tts_finished)
 
+    def _tts_finished(self) -> None:
+        self._pipeline_active = False
+        self.state.active_wake_words.discard(self.state.stop_word.id)
+        self.send_messages([VoiceAssistantAnnounceFinished()])
+        self._emit(LVAEvent.TTS_FINISHED)
+
+        if self._continue_conversation:
+            self.send_messages([VoiceAssistantRequest(start=True)])
+            self._is_streaming_audio = True
+            self._pipeline_active = True
+            self._emit(LVAEvent.LISTENING)
+            _LOGGER.debug("Continuing conversation")
+            def _start_continued_conversation() -> None:
+                if self.state.muted:
+                    _LOGGER.debug("Skipping continued conversation: muted")
+                    self._pipeline_active = False
+                    self.unduck()
+                    return
+                self.send_messages([VoiceAssistantRequest(start=True)])
+                self._is_streaming_audio = True
+                _LOGGER.debug("Continued conversation started")
+
+            threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()            
+        else:
+            self.unduck()
+            self._emit(LVAEvent.IDLE)
+
+        _LOGGER.debug("TTS response finished")
+    
     def duck(self) -> None:
         _LOGGER.debug("Ducking music")
         self.state.music_player.duck()

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -719,7 +719,7 @@ class VoiceSatelliteProtocol(APIServer):
             # and does not capture the tail end of the TTS audio from the speaker.
             self._pipeline_active = True
             _LOGGER.debug("Continuing conversation after %.2fs settle delay", self.state.continue_conversation_delay)
-    
+
             def _start_continued_conversation() -> None:
                 if self.state.muted:
                     _LOGGER.debug("Skipping continued conversation: muted")
@@ -729,7 +729,7 @@ class VoiceSatelliteProtocol(APIServer):
                 self.send_messages([VoiceAssistantRequest(start=True)])
                 self._is_streaming_audio = True
                 _LOGGER.debug("Continued conversation started")
-    
+
             threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
         else:
             self._continue_conversation = False

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -715,7 +715,7 @@ class VoiceSatelliteProtocol(APIServer):
                 self._is_streaming_audio = True
                 _LOGGER.debug("Continued conversation started")
 
-            threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()            
+            threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
         else:
             self.unduck()
             self._emit(LVAEvent.IDLE)

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -708,34 +708,34 @@ class VoiceSatelliteProtocol(APIServer):
         _LOGGER.debug("Unducking music")
         self.state.music_player.unduck()
 
-def _tts_finished(self) -> None:
-    self._pipeline_active = False
-    self.state.active_wake_words.discard(self.state.stop_word.id)
-    self.send_messages([VoiceAssistantAnnounceFinished()])
-
-    if self._continue_conversation:
-        self._continue_conversation = False
-        # Keep pipeline active during the settle delay so the mic stays closed
-        # and does not capture the tail end of the TTS audio from the speaker.
-        self._pipeline_active = True
-        _LOGGER.debug("Continuing conversation after %.2fs settle delay", self.state.continue_conversation_delay)
-
-        def _start_continued_conversation() -> None:
-            if self.state.muted:
-                _LOGGER.debug("Skipping continued conversation: muted")
-                self._pipeline_active = False
-                self.unduck()
-                return
-            self.send_messages([VoiceAssistantRequest(start=True)])
-            self._is_streaming_audio = True
-            _LOGGER.debug("Continued conversation started")
-
-        threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
-    else:
-        self._continue_conversation = False
-        self.unduck()
-
-    _LOGGER.debug("TTS response finished")
+    def _tts_finished(self) -> None:
+        self._pipeline_active = False
+        self.state.active_wake_words.discard(self.state.stop_word.id)
+        self.send_messages([VoiceAssistantAnnounceFinished()])
+    
+        if self._continue_conversation:
+            self._continue_conversation = False
+            # Keep pipeline active during the settle delay so the mic stays closed
+            # and does not capture the tail end of the TTS audio from the speaker.
+            self._pipeline_active = True
+            _LOGGER.debug("Continuing conversation after %.2fs settle delay", self.state.continue_conversation_delay)
+    
+            def _start_continued_conversation() -> None:
+                if self.state.muted:
+                    _LOGGER.debug("Skipping continued conversation: muted")
+                    self._pipeline_active = False
+                    self.unduck()
+                    return
+                self.send_messages([VoiceAssistantRequest(start=True)])
+                self._is_streaming_audio = True
+                _LOGGER.debug("Continued conversation started")
+    
+            threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
+        else:
+            self._continue_conversation = False
+            self.unduck()
+    
+        _LOGGER.debug("TTS response finished")
 
     def _play_timer_finished(self) -> None:
         if not self._timer_finished:

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -700,36 +700,6 @@ class VoiceSatelliteProtocol(APIServer):
         self.state.active_wake_words.add(self.state.stop_word.id)
         self.state.tts_player.play(self._tts_url, done_callback=self._tts_finished)
 
-    def _tts_finished(self) -> None:
-        self._pipeline_active = False
-        self.state.active_wake_words.discard(self.state.stop_word.id)
-        self.send_messages([VoiceAssistantAnnounceFinished()])
-        self._emit(LVAEvent.TTS_FINISHED)
-
-        if self._continue_conversation:
-            self.send_messages([VoiceAssistantRequest(start=True)])
-            self._is_streaming_audio = True
-            self._pipeline_active = True
-            self._emit(LVAEvent.LISTENING)
-            _LOGGER.debug("Continuing conversation")
-
-            def _start_continued_conversation() -> None:
-                if self.state.muted:
-                    _LOGGER.debug("Skipping continued conversation: muted")
-                    self._pipeline_active = False
-                    self.unduck()
-                    return
-                self.send_messages([VoiceAssistantRequest(start=True)])
-                self._is_streaming_audio = True
-                _LOGGER.debug("Continued conversation started")
-
-            threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
-        else:
-            self.unduck()
-            self._emit(LVAEvent.IDLE)
-
-        _LOGGER.debug("TTS response finished")
-
     def duck(self) -> None:
         _LOGGER.debug("Ducking music")
         self.state.music_player.duck()
@@ -738,20 +708,34 @@ class VoiceSatelliteProtocol(APIServer):
         _LOGGER.debug("Unducking music")
         self.state.music_player.unduck()
 
-    def _tts_finished(self) -> None:
-        self._pipeline_active = False
-        self.state.active_wake_words.discard(self.state.stop_word.id)
-        self.send_messages([VoiceAssistantAnnounceFinished()])
+def _tts_finished(self) -> None:
+    self._pipeline_active = False
+    self.state.active_wake_words.discard(self.state.stop_word.id)
+    self.send_messages([VoiceAssistantAnnounceFinished()])
 
-        if self._continue_conversation:
+    if self._continue_conversation:
+        self._continue_conversation = False
+        # Keep pipeline active during the settle delay so the mic stays closed
+        # and does not capture the tail end of the TTS audio from the speaker.
+        self._pipeline_active = True
+        _LOGGER.debug("Continuing conversation after %.2fs settle delay", self.state.continue_conversation_delay)
+
+        def _start_continued_conversation() -> None:
+            if self.state.muted:
+                _LOGGER.debug("Skipping continued conversation: muted")
+                self._pipeline_active = False
+                self.unduck()
+                return
             self.send_messages([VoiceAssistantRequest(start=True)])
             self._is_streaming_audio = True
-            self._pipeline_active = True
-            _LOGGER.debug("Continuing conversation")
-        else:
-            self.unduck()
+            _LOGGER.debug("Continued conversation started")
 
-        _LOGGER.debug("TTS response finished")
+        threading.Timer(self.state.continue_conversation_delay, _start_continued_conversation).start()
+    else:
+        self._continue_conversation = False
+        self.unduck()
+
+    _LOGGER.debug("TTS response finished")
 
     def _play_timer_finished(self) -> None:
         if not self._timer_finished:

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -734,7 +734,7 @@ class VoiceSatelliteProtocol(APIServer):
         else:
             self._continue_conversation = False
             self.unduck()
-    
+
         _LOGGER.debug("TTS response finished")
 
     def _play_timer_finished(self) -> None:

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -705,6 +705,7 @@ class VoiceSatelliteProtocol(APIServer):
             self._pipeline_active = True
             self._emit(LVAEvent.LISTENING)
             _LOGGER.debug("Continuing conversation")
+
             def _start_continued_conversation() -> None:
                 if self.state.muted:
                     _LOGGER.debug("Skipping continued conversation: muted")
@@ -721,7 +722,7 @@ class VoiceSatelliteProtocol(APIServer):
             self._emit(LVAEvent.IDLE)
 
         _LOGGER.debug("TTS response finished")
-    
+
     def duck(self) -> None:
         _LOGGER.debug("Ducking music")
         self.state.music_player.duck()


### PR DESCRIPTION
Add a configurable amount of delay (defaulting to 0.5s) after the TTS playback is finished to avoid the mic to capture the end of response during start/continue conversation.

Fixes #313 