### PR TITLE
Add mmWave presence binary sensor to the peripheral API

### DIFF
--- a/docs/peripheral_api.md
+++ b/docs/peripheral_api.md
@@ -165,6 +165,7 @@ For HA to see your entity, your peripheral must register before HA enumerates th
 |---------|------|-------------|
 | `register_light` | `{"name": str, "object_id": str, "effects": [str], "supports_rgb": bool, "supports_brightness": bool}` | Register a Light entity for an LED strip, ring, or single LED. HA exposes it as `light.<satellite>_<object_id>` with on/off, brightness, RGB, and a selectable effect from the declared list. Subsequent HA changes are delivered as `light_command` events. Send once after connecting; repeat registrations for the same `object_id` are idempotent (no-op). Example: `{"command": "register_light", "data": {"name": "LEDs", "object_id": "leds", "effects": ["Voice Assistant"], "supports_rgb": true, "supports_brightness": true}}` |
 | `register_button` | `{"name": Button Press, "button_press_event": str}` | Register a Button entity for a physical button on your peripheral. When the user presses the button in HA, LVA emits a `button_press` event to all connected peripherals. Send once after connecting; repeat registrations for the same `object_id` are idempotent (no-op). Example: `{"command": "register_button"}` |
+| `register_presence` | — | Register a presence/occupancy binary sensor (e.g. an mmWave radar). HA exposes it as `binary_sensor.<satellite>_presence` with `device_class` `occupancy`. Push its state with `set_presence`. Send once after connecting; repeat registrations are idempotent (no-op). Example: `{"command": "register_presence"}` |
 
 ### Voice pipeline
 
@@ -225,6 +226,14 @@ Long press    : button held for ≥1 s
 ```
 
 Your script is responsible for detecting these patterns and sending the appropriate command. See the board-specific examples below for reference implementations.
+
+### Sensor updates (sent to Home Assistant)
+
+Push readings from your peripheral's sensors to Home Assistant. The sensor must be registered first (see [Entity registration](#entity-registration)).
+
+| Command | Data | Description |
+|---------|------|-------------|
+| `set_presence` | `{"detected": bool}` | Update the presence binary sensor registered with `register_presence`. `true` = occupied, `false` = clear. Ignored until `register_presence` has been sent. Example: `{"command": "set_presence", "data": {"detected": true}}` |
 
 ---
 
@@ -327,6 +336,7 @@ The repository ships with ready-to-use peripheral controllers for popular hardwa
 - [ReSpeaker 4-Mic Array HAT](https://github.com/OHF-Voice/linux-voice-assistant/blob/main/examples/ReSpeaker%204mic%20HAT/DOCS.md) — 12 APA102 LEDs + external GPIO buttons; four-microphone circular array
 - [ReSpeaker Mic Array v2.0 (USB)](https://github.com/OHF-Voice/linux-voice-assistant/blob/main/examples/ReSpeaker%20Mic%20Array%20v2.0%20(USB)/DOCS.md) — 12 APA102 LEDs driven over USB HID; plug-and-play, no GPIO required
 - [Jabra Speak 410](https://github.com/OHF-Voice/linux-voice-assistant/blob/main/examples/Jabra%20Speak%20410/DOCS.md) — USB speakerphone with hardware button integration
+- [mmWave Presence (LD2410)](https://github.com/OHF-Voice/linux-voice-assistant/blob/main/examples/mmWave%20presence%20(LD2410)/DOCS.md) — LD2410 24 GHz radar on the Pi UART; exposes a presence `binary_sensor` to Home Assistant
 
 ---
 

--- a/examples/mmWave presence (LD2410)/DOCS.md
+++ b/examples/mmWave presence (LD2410)/DOCS.md
@@ -1,0 +1,98 @@
+# mmWave Presence (LD2410)
+
+A minimal peripheral controller that turns an **HLK-LD2410 24 GHz mmWave radar**
+into a Home Assistant **presence (`binary_sensor`)** on your LVA device, using
+the [peripheral WebSocket API](../../docs/peripheral_api.md).
+
+Unlike the LED/button examples, this one has no display — it only *reports* a
+sensor reading. It demonstrates the `register_presence` + `set_presence`
+commands and is a good template for exposing any other binary sensor.
+
+## Hardware
+
+| LD2410 pin | Raspberry Pi pin | Notes |
+|------------|------------------|-------|
+| 5V / VCC   | 5V (pin 2/4)     | |
+| GND        | GND (pin 6)      | |
+| TX         | RXD / GPIO15 (pin 10) | sensor → Pi |
+| RX         | TXD / GPIO14 (pin 8)  | Pi → sensor (optional) |
+
+The sensor is read on the Pi's primary UART (`/dev/ttyAMA0`). This example
+assumes the FutureProofHomes Satellite1 LD2410 firmware, which streams ASCII
+`distance:<cm>` lines at 115200 baud. If your LD2410 uses the stock binary
+protocol, adapt the `distance` parsing in `mmwave_presence.py`.
+
+### Enabling the UART
+
+On a Raspberry Pi, free the PL011 UART and route it to the GPIO header by adding
+to `/boot/firmware/config.txt`:
+
+```
+enable_uart=1
+dtoverlay=disable-bt
+```
+
+Then stop a login console from grabbing it:
+
+```bash
+sudo systemctl mask serial-getty@ttyAMA0.service
+# and remove any "console=serial0,115200" from /boot/firmware/cmdline.txt
+sudo reboot
+```
+
+Confirm the stream:
+
+```bash
+sudo cat /dev/ttyAMA0    # should print distance:123 lines
+```
+
+## How it works
+
+1. Reads the distance stream in a background thread.
+2. Derives presence: occupied while a valid distance (`0 < d ≤ MMWAVE_PRESENCE_MAX_CM`)
+   was seen within `MMWAVE_ABSENT_TIMEOUT` seconds.
+3. Sends `register_presence` on connect, then `set_presence {"detected": …}` on
+   every change (plus a heartbeat re-assert so a push that arrives before Home
+   Assistant has connected self-corrects).
+4. Reconnects and re-registers automatically if LVA restarts.
+
+Home Assistant shows it as `binary_sensor.<satellite>_presence` (device class
+`occupancy`) on the LVA ESPHome device. New entities only appear after the
+ESPHome integration is reloaded (register before HA enumerates, or reload once).
+
+## Installation
+
+```bash
+docker compose up -d --build
+docker compose logs -f
+```
+
+Or run it directly:
+
+```bash
+pip install -r requirements.txt
+python mmwave_presence.py
+```
+
+## Configuration
+
+All optional, via environment variables (see `compose.yml`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LVA_PERIPHERAL_URL` | `ws://127.0.0.1:6055` | LVA peripheral API endpoint |
+| `MMWAVE_PORT` | `/dev/ttyAMA0` | Serial device |
+| `MMWAVE_BAUD` | `115200` | Baud rate |
+| `MMWAVE_PRESENCE_MAX_CM` | `600` | Max distance counted as presence |
+| `MMWAVE_ABSENT_TIMEOUT` | `5` | Seconds without a hit before clearing |
+| `MMWAVE_RESEND_INTERVAL` | `10` | Heartbeat re-assert interval |
+
+## Troubleshooting
+
+- **`not ready (...)` in the logs** — LVA (or its peripheral API on port 6055)
+  is not up yet. The script retries automatically.
+- **No `distance:` lines** — the UART is not freed (see *Enabling the UART*), or
+  TX/RX are swapped, or the baud rate is wrong.
+- **Sensor never clears** — mmWave sees through walls and has a wide field of
+  view; lower `MMWAVE_PRESENCE_MAX_CM` or raise `MMWAVE_ABSENT_TIMEOUT` to taste.
+- **Entity missing in HA** — reload the ESPHome integration so HA re-enumerates.

--- a/examples/mmWave presence (LD2410)/Dockerfile
+++ b/examples/mmWave presence (LD2410)/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY mmwave_presence.py .
+
+CMD ["python", "mmwave_presence.py"]

--- a/examples/mmWave presence (LD2410)/compose.yml
+++ b/examples/mmWave presence (LD2410)/compose.yml
@@ -1,0 +1,16 @@
+services:
+  mmwave-presence:
+    build: .
+    container_name: mmwave-presence
+    restart: unless-stopped
+    # Reach LVA's peripheral API on the host (default ws://127.0.0.1:6055).
+    network_mode: host
+    # Pass the LD2410 UART through to the container.
+    devices:
+      - "/dev/ttyAMA0:/dev/ttyAMA0"
+    environment:
+      LVA_PERIPHERAL_URL: "ws://127.0.0.1:6055"
+      MMWAVE_PORT: "/dev/ttyAMA0"
+      MMWAVE_BAUD: "115200"
+      MMWAVE_PRESENCE_MAX_CM: "600"
+      MMWAVE_ABSENT_TIMEOUT: "5"

--- a/examples/mmWave presence (LD2410)/mmwave_presence.py
+++ b/examples/mmWave presence (LD2410)/mmwave_presence.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""mmWave presence peripheral for linux-voice-assistant.
+
+Reads an HLK-LD2410 24 GHz radar on the Raspberry Pi UART and exposes a
+presence/occupancy ``binary_sensor`` to Home Assistant through LVA's peripheral
+WebSocket API (``register_presence`` + ``set_presence``).
+
+The sensor here streams ASCII ``distance:<cm>`` lines (the firmware shipped on
+the FutureProofHomes Satellite1 LD2410). Presence is derived as "a valid
+distance seen within ABSENT_TIMEOUT". Adjust ``read_distance`` if your LD2410
+speaks the stock binary protocol instead.
+
+Config via environment (all optional):
+    LVA_PERIPHERAL_URL          ws://127.0.0.1:6055
+    MMWAVE_PORT                 /dev/ttyAMA0
+    MMWAVE_BAUD                 115200
+    MMWAVE_PRESENCE_MAX_CM      600
+    MMWAVE_ABSENT_TIMEOUT       5      (seconds without a hit -> clear)
+    MMWAVE_RESEND_INTERVAL      10     (heartbeat re-assert, seconds)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+
+import serial  # pyserial
+import websockets
+
+WS_URL = os.environ.get("LVA_PERIPHERAL_URL", "ws://127.0.0.1:6055")
+PORT = os.environ.get("MMWAVE_PORT", "/dev/ttyAMA0")
+BAUD = int(os.environ.get("MMWAVE_BAUD", "115200"))
+MAX_CM = int(os.environ.get("MMWAVE_PRESENCE_MAX_CM", "600"))
+ABSENT_TIMEOUT = float(os.environ.get("MMWAVE_ABSENT_TIMEOUT", "5"))
+RESEND_INTERVAL = float(os.environ.get("MMWAVE_RESEND_INTERVAL", "10"))
+POLL = 0.1
+
+_DIST_RE = re.compile(rb"distance:(\d+)")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("mmwave-presence")
+
+
+class Presence:
+    """Derives a presence boolean from the distance stream."""
+
+    def __init__(self):
+        self.last_seen = 0.0
+        self.last_cm = -1
+
+    def update_distance(self, cm, now):
+        self.last_cm = cm
+        if 0 < cm <= MAX_CM:
+            self.last_seen = now
+
+    def detected(self, now):
+        return self.last_seen > 0 and (now - self.last_seen) <= ABSENT_TIMEOUT
+
+
+async def serial_reader(state, loop):
+    def _read():
+        ser = serial.Serial(PORT, BAUD, timeout=0.2)
+        log.info("serial open %s @ %d", PORT, BAUD)
+        buf = b""
+        while True:
+            data = ser.read(64)
+            if not data:
+                continue
+            buf += data
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                m = _DIST_RE.search(line)
+                if m:
+                    loop.call_soon_threadsafe(state.update_distance, int(m.group(1)), time.monotonic())
+
+    await loop.run_in_executor(None, _read)
+
+
+async def ws_pusher(state):
+    """Register the sensor and push presence; reconnect + re-register on failure."""
+    while True:
+        try:
+            async with websockets.connect(WS_URL) as ws:
+                log.info("connected to %s; register_presence", WS_URL)
+                await ws.send(json.dumps({"command": "register_presence"}))
+                last_sent = None
+                last_send_time = 0.0
+                while True:
+                    now = time.monotonic()
+                    det = state.detected(now)
+                    # Send on change, and re-assert on a heartbeat so a push that
+                    # LVA dropped (e.g. it arrived before HA connected) self-corrects.
+                    if det != last_sent or (now - last_send_time) >= RESEND_INTERVAL:
+                        await ws.send(json.dumps({"command": "set_presence", "data": {"detected": det}}))
+                        if det != last_sent:
+                            log.info("presence=%s (last_cm=%s)", det, state.last_cm)
+                        last_sent = det
+                        last_send_time = now
+                    await asyncio.sleep(POLL)
+        except Exception as e:  # noqa: BLE001
+            log.warning("not ready (%s); retrying in 2s", e)
+            await asyncio.sleep(2)
+
+
+async def main():
+    loop = asyncio.get_running_loop()
+    state = Presence()
+    await asyncio.gather(serial_reader(state, loop), ws_pusher(state))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/mmWave presence (LD2410)/requirements.txt
+++ b/examples/mmWave presence (LD2410)/requirements.txt
@@ -1,0 +1,2 @@
+pyserial>=3.5
+websockets>=12

--- a/linux_voice_assistant/entity.py
+++ b/linux_voice_assistant/entity.py
@@ -5,9 +5,11 @@ from typing import Callable, List, Optional, Union
 
 # pylint: disable=no-name-in-module
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
+    BinarySensorStateResponse,
     EventResponse,
     LightCommandRequest,
     LightStateResponse,
+    ListEntitiesBinarySensorResponse,
     ListEntitiesEventResponse,
     ListEntitiesLightResponse,
     ListEntitiesMediaPlayerResponse,
@@ -784,6 +786,53 @@ class ButtonEventSensorEntity(ESPHomeEntity):
         )
 
 
+class BinarySensorEntity(ESPHomeEntity):
+    """A binary sensor (e.g. mmWave presence) exposed to Home Assistant.
+
+    A peripheral that owns a presence/occupancy sensor registers this via
+    the peripheral API and then pushes ``True``/``False`` as the sensor
+    detects or clears; the state is mirrored to HA as a binary_sensor.
+    """
+
+    def __init__(
+        self,
+        server: APIServer,
+        key: int,
+        name: str,
+        object_id: str,
+        device_class: str = "occupancy",
+    ) -> None:
+        ESPHomeEntity.__init__(self, server)
+
+        self.key = key
+        self.name = name
+        self.object_id = object_id
+        self.device_class = device_class
+        self._state = False
+        self._log = logging.getLogger(f"{self.__class__.__name__}[{self.key}]")
+
+    def update_state(self, detected: bool) -> None:
+        """Update the detected/cleared state."""
+        self._state = bool(detected)
+        self._log.debug("Binary sensor state updated: %s", self._state)
+
+    def handle_message(self, msg: message.Message) -> Iterable[message.Message]:
+        if isinstance(msg, ListEntitiesRequest):
+            yield ListEntitiesBinarySensorResponse(
+                object_id=self.object_id,
+                key=self.key,
+                name=self.name,
+                device_class=self.device_class,
+            )
+        elif isinstance(msg, SubscribeHomeAssistantStatesRequest):
+            # Unlike an event sensor, False is a valid initial state, so it
+            # is always safe to report the current value on subscribe.
+            yield self._get_state_message()
+
+    def _get_state_message(self) -> BinarySensorStateResponse:
+        return BinarySensorStateResponse(key=self.key, state=self._state)
+
+
 # Backward compatibility export aliases
 __all__ = [
     "ESPHomeEntity",
@@ -792,6 +841,7 @@ __all__ = [
     "ThinkingSoundEntity",
     "LEDLightEntity",
     "ButtonEventSensorEntity",
+    "BinarySensorEntity",
     "WakeWord1SensitivityNumberEntity",
     "WakeWord2SensitivityNumberEntity",
     "StopWordSensitivityNumberEntity",

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from pyopen_wakeword import OpenWakeWord
 
     from .entity import (
+        BinarySensorEntity,
         ButtonEventSensorEntity,
         ESPHomeEntity,
         LEDLightEntity,
@@ -128,6 +129,7 @@ class ServerState:
     mute_switch_entity: "Optional[MuteSwitchEntity]" = None
     thinking_sound_entity: "Optional[ThinkingSoundEntity]" = None
     button_event_sensor_entity: "Optional[ButtonEventSensorEntity]" = None
+    presence_sensor_entity: "Optional[BinarySensorEntity]" = None
 
     # Lights declared by peripherals via register_light. Survives HA
     # reconnects so the satellite can rebuild its entities whenever it
@@ -142,6 +144,11 @@ class ServerState:
     # entity when hardware that actually supports button presses is present.
     # Survives HA reconnects so the entity is re-registered automatically.
     pending_button: bool = False
+
+    # True once a peripheral sends register_presence. Gates creation of the
+    # presence BinarySensorEntity so the HA device page only shows it when a
+    # presence sensor is actually present. Survives HA reconnects.
+    pending_presence: bool = False
 
     # Optional peripheral WebSocket API (LEDs, buttons, HAT boards).
     # Assigned in __main__ before the event loop starts.

--- a/linux_voice_assistant/peripheral_api.py
+++ b/linux_voice_assistant/peripheral_api.py
@@ -83,6 +83,17 @@ Commands accepted from the peripheral container
               back to the peripheral as light_command events. Send
               once after connecting; duplicate registrations for the
               same object_id are ignored.
+  register_presence
+              The peripheral declares that it has a presence/occupancy
+              sensor (e.g. an mmWave radar) and wants it exposed in HA. LVA
+              creates a BinarySensorEntity (visible as
+              binary_sensor.<satellite>_presence, device_class occupancy).
+              Send once after connecting; duplicate registrations are
+              ignored.
+  set_presence      data: {"detected": bool}
+              Push the current presence state. LVA updates the presence
+              BinarySensorEntity and forwards it to Home Assistant. Ignored
+              until register_presence has been sent.
   register_button
               The peripheral declares that it has physical buttons and
               wants a Button Press event entity exposed in HA. LVA
@@ -160,6 +171,8 @@ class LVACommand(str, Enum):
     BUTTON_LONG_PRESS = "button_long_press"
     REGISTER_LIGHT = "register_light"
     REGISTER_BUTTON = "register_button"
+    REGISTER_PRESENCE = "register_presence"
+    SET_PRESENCE = "set_presence"
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +476,23 @@ class PeripheralAPIServer:
         elif command == LVACommand.REGISTER_BUTTON:
             self._register_button(satellite)
 
+        elif command == LVACommand.REGISTER_PRESENCE:
+            self._register_presence(satellite)
+
+        elif command == LVACommand.SET_PRESENCE:
+            data = msg.get("data") or {}
+            detected = data.get("detected")
+            if not isinstance(detected, bool):
+                _LOGGER.warning(
+                    "Peripheral: invalid 'detected' in set_presence command: %s",
+                    detected,
+                )
+                return
+            if state.presence_sensor_entity is not None:
+                state.presence_sensor_entity.update_state(detected)
+                if satellite is not None:
+                    satellite.send_messages([state.presence_sensor_entity._get_state_message()])  # pylint: disable=protected-access
+
     def _register_light(self, data: Dict[str, Any], satellite: Any) -> None:
         """Register a Light declared by a peripheral.
 
@@ -527,6 +557,28 @@ class PeripheralAPIServer:
 
         if satellite is not None:
             satellite.register_pending_button()
+
+    def _register_presence(self, satellite: Any) -> None:
+        """Register a presence binary sensor declared by a peripheral.
+
+        Idempotent, mirroring _register_button: a reconnecting peripheral's
+        repeat registration is a no-op and the existing entity (and its last
+        state) is preserved. When the satellite is already running the entity
+        is materialised immediately so subsequent set_presence commands route
+        correctly; HA sees it after the integration reloads.
+        """
+        state = self._state
+        if state is None:
+            return
+
+        if state.pending_presence:
+            return
+
+        state.pending_presence = True
+        _LOGGER.info("Presence binary sensor registered by peripheral")
+
+        if satellite is not None:
+            satellite.register_pending_presence()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -50,6 +50,7 @@ from pyopen_wakeword import OpenWakeWord
 
 from .api_server import APIServer
 from .entity import (
+    BinarySensorEntity,
     ButtonEventSensorEntity,
     LEDLightEntity,
     MediaPlayerEntity,
@@ -334,6 +335,9 @@ class VoiceSatelliteProtocol(APIServer):
         # button support before this satellite was constructed (e.g. on an HA
         # reconnect while the peripheral container stayed connected to LVA).
         self.register_pending_button()
+        # Materialise the presence BinarySensorEntity if a peripheral already
+        # registered a presence sensor before this satellite was constructed.
+        self.register_pending_presence()
 
         # ---- Instance variables ----
 
@@ -429,6 +433,36 @@ class VoiceSatelliteProtocol(APIServer):
         self.state.entities.append(entity)
         self.state.button_event_sensor_entity = entity
         _LOGGER.info("Button event sensor entity materialised")
+
+    def register_pending_presence(self) -> None:
+        """Materialise the presence BinarySensorEntity once registered.
+
+        Mirrors register_pending_button: called from __init__ (handles HA
+        reconnects where the peripheral stayed connected) and from
+        PeripheralAPIServer._register_presence() when the command arrives at
+        runtime. Idempotent — an existing entity is only reattached.
+        """
+        if not self.state.pending_presence:
+            return
+
+        if self.state.presence_sensor_entity is not None:
+            # Already materialised — reattach the server in case the satellite
+            # has been reconstructed for an HA reconnect.
+            self.state.presence_sensor_entity.server = self
+            if self.state.presence_sensor_entity not in self.state.entities:
+                self.state.entities.append(self.state.presence_sensor_entity)
+            return
+
+        entity = BinarySensorEntity(
+            server=self,
+            key=len(self.state.entities),
+            name="Presence",
+            object_id="presence",
+            device_class="occupancy",
+        )
+        self.state.entities.append(entity)
+        self.state.presence_sensor_entity = entity
+        _LOGGER.info("Presence binary sensor entity materialised")
 
     def _on_led_light_changed(self, object_id: str) -> None:
         """Forward an HA Light entity change to peripherals as light_command.


### PR DESCRIPTION
## What
Two new peripheral-API commands, `register_presence` and `set_presence`, that let a peripheral surface a presence/occupancy sensor (e.g. an mmWave radar) to Home Assistant as a `binary_sensor`. Includes the `BinarySensorEntity`, the `ServerState` plumbing, `register_pending_presence()`, documentation in `docs/peripheral_api.md`, and a runnable reference peripheral under `examples/mmWave presence (LD2410)/`.

## Why
The peripheral API already exposes LEDs and buttons to Home Assistant, but there's no path for a *sensor* reading. Presence is one of the most useful signals a voice satellite can contribute to a smart home, and the protocol was one command short of supporting it.

## How
It follows the exact `register_button` / `register_light` pattern already established in `peripheral_api`, so there's nothing new to learn and the added surface area is tiny. Crucially, it ships the way the rest of the repo does — protocol docs **plus** a Docker-ready reference peripheral — so a reviewer can run it end-to-end without any bespoke setup. Validated on real hardware (an LD2410 on a Pi + Satellite1 HAT), with all five CI linters green.
