### PR TITLE
Revert "Broadcast entity state to all API clients; don't desync on a second connection"

### DIFF
--- a/linux_voice_assistant/entity.py
+++ b/linux_voice_assistant/entity.py
@@ -89,19 +89,6 @@ class MediaPlayerEntity(ESPHomeEntity):
         self.apply_volume_from_state(initial_volume)
         self._log = logging.getLogger(f"{self.__class__.__name__}[{self.key}]")
 
-    def _broadcast_state(self, msgs: Iterable[message.Message]) -> None:
-        """Push an asynchronous state change to all connected clients.
-
-        Playback-completion callbacks fire outside any request, so the update
-        must reach every subscribed client rather than the single connection in
-        ``self.server`` (which may belong to another client, or be closed).
-        """
-        state = getattr(self.server, "state", None)
-        if state is not None:
-            state.broadcast(msgs)
-        else:  # pragma: no cover - no ServerState (e.g. a bare APIServer)
-            self.server.send_messages(msgs)
-
     def play(
         self,
         url: Union[str, List[str]],
@@ -122,7 +109,7 @@ class MediaPlayerEntity(ESPHomeEntity):
                 self.announce_player.play(
                     url,
                     done_callback=lambda: call_all(
-                        self._broadcast_state([self._update_state(MediaPlayerState.IDLE)]),
+                        self.server.send_messages([self._update_state(MediaPlayerState.IDLE)]),
                         done_callback,
                     ),
                 )
@@ -132,7 +119,7 @@ class MediaPlayerEntity(ESPHomeEntity):
             self.music_player.play(
                 url,
                 done_callback=lambda: call_all(
-                    self._broadcast_state([self._update_state(MediaPlayerState.IDLE)]),
+                    self.server.send_messages([self._update_state(MediaPlayerState.IDLE)]),
                     done_callback,
                 ),
             )

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -10,7 +9,6 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 if TYPE_CHECKING:
-    from google.protobuf import message
     from pymicro_wakeword import MicroWakeWord
     from pyopen_wakeword import OpenWakeWord
 
@@ -127,7 +125,6 @@ class ServerState:
 
     media_player_entity: "Optional[MediaPlayerEntity]" = None
     satellite: "Optional[VoiceSatelliteProtocol]" = None
-    connections: "List[VoiceSatelliteProtocol]" = field(default_factory=list)
     mute_switch_entity: "Optional[MuteSwitchEntity]" = None
     thinking_sound_entity: "Optional[ThinkingSoundEntity]" = None
     button_event_sensor_entity: "Optional[ButtonEventSensorEntity]" = None
@@ -174,21 +171,6 @@ class ServerState:
     mic_volume: int = 100  # 1–100, default maximum
     audio_input_channels: int = 2  # number of mic channels to stream
     timer_max_ring_seconds: float = 900.0
-
-    def broadcast(self, msgs: "Iterable[message.Message]") -> None:
-        """Send messages to every connected API client.
-
-        Entity state changes that happen asynchronously (not in response to a
-        request) must reach *all* subscribed clients, not just whichever
-        connection happens to be referenced by an entity's ``server``. Without
-        this fan-out a second API client leaves Home Assistant stuck on a stale
-        state (e.g. ``playing`` after playback has finished).
-        """
-        messages = list(msgs)
-        if not messages:
-            return
-        for connection in list(self.connections):
-            connection.send_messages(messages)
 
     def save_preferences(self) -> None:
         """Save preferences as JSON."""

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -25,7 +25,6 @@ from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     NumberCommandRequest,
     SelectCommandRequest,
     SubscribeHomeAssistantStatesRequest,
-    SubscribeStatesRequest,
     SwitchCommandRequest,
     VoiceAssistantAnnounceFinished,
     VoiceAssistantAnnounceRequest,
@@ -658,12 +657,7 @@ class VoiceSatelliteProtocol(APIServer):
                 model="Linux Voice Assistant",
                 voice_assistant_feature_flags=self.supported_features,
             )
-        elif isinstance(msg, SubscribeStatesRequest):
-            # Standard ESPHome state subscription. Replay current entity state to
-            # the subscribing client. (Entities answer SubscribeHomeAssistantStatesRequest;
-            # initial state was previously only sent as a side effect of auth.)
-            for entity in self.state.entities:
-                yield from entity.handle_message(SubscribeHomeAssistantStatesRequest())
+
         elif isinstance(
             msg,
             (ListEntitiesRequest, SubscribeHomeAssistantStatesRequest, MediaPlayerCommandRequest, SwitchCommandRequest, NumberCommandRequest, SelectCommandRequest, LightCommandRequest),
@@ -993,13 +987,6 @@ class VoiceSatelliteProtocol(APIServer):
             ),
         )
 
-    def connection_made(self, transport) -> None:
-        super().connection_made(transport)
-        # Track every live connection so asynchronous entity-state changes can be
-        # broadcast to all of them (see ServerState.broadcast).
-        if self not in self.state.connections:
-            self.state.connections.append(self)
-
     # ------------------------------------------------------------------
     # Connection lifecycle
     # ------------------------------------------------------------------
@@ -1015,29 +1002,19 @@ class VoiceSatelliteProtocol(APIServer):
         self._timer_finished = False
         self._pipeline_active = False
 
-        # Deregister this connection.
-        if self in self.state.connections:
-            self.state.connections.remove(self)
+        # Stop any ongoing audio playback and wake/stop word processing.
+        try:
+            self.state.music_player.stop()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to stop music player during disconnect")
 
-        # Only tear down shared playback/state when the LAST client disconnects.
-        # Otherwise a secondary client (a diagnostic tool, a second dashboard, or
-        # Home Assistant's own overlapping reconnect) dropping would stop audio
-        # that belongs to a client still connected.
-        if not self.state.connections:
-            # Stop any ongoing audio playback and wake/stop word processing.
-            try:
-                self.state.music_player.stop()
-            except Exception:  # pragma: no cover - defensive safety net
-                _LOGGER.exception("Failed to stop music player during disconnect")
+        try:
+            self.state.tts_player.stop()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to stop TTS player during disconnect")
 
-            try:
-                self.state.tts_player.stop()
-            except Exception:  # pragma: no cover - defensive safety net
-                _LOGGER.exception("Failed to stop TTS player during disconnect")
-
-            self.state.stop_word.is_active = False
-            self.state.connected = False
-
+        self.state.stop_word.is_active = False  # type: ignore[attr-defined]
+        self.state.connected = False
         if self.state.satellite is self:
             self.state.satellite = None
 


### PR DESCRIPTION
Reverts OHF-Voice/linux-voice-assistant#329 to fix lint then update it back