### PR TITLE
docs: add realtime scheduling tuning for constrained hardware Closes #164

### DIFF
--- a/docs/install_audioserver.md
+++ b/docs/install_audioserver.md
@@ -54,11 +54,31 @@ sudo mkdir -p /etc/pipewire/pipewire.conf.d
 sudo vi /etc/pipewire/pipewire.conf.d/linux-voice-assistant.conf
 ```
 
+💡 **Note:** On constrained hardware like a Raspberry Pi 3B, audio
+processing can be interrupted by other system activity, causing
+audible glitches or dropped wake-word detections. Loading the
+`libpipewire-module-rt` module raises PipeWire's scheduling priority
+(`rt.prio`) above normal processes, which reduces these interruptions.
+The `flags = [ ifexists nofail ]` ensures this configuration is
+silently skipped rather than causing a startup failure on systems
+where realtime scheduling isn't available (e.g. some containers or
+restricted kernels).
+
 Add the following content:
 ```
 context.properties = {
     default.clock.rate = 16000
 }
+
+context.modules = [
+    {   name = libpipewire-module-rt
+        args = {
+            nice.level    = -11
+            rt.prio       = 88
+        }
+        flags = [ ifexists nofail ]
+    }
+]
 ```
 
 #### Applying the Changes


### PR DESCRIPTION
The core problem in #164 (config fully overriding pipewire.conf) was already fixed by switching to pipewire.conf.d. This adds the remaining performance-tuning recommendation (libpipewire-module-rt) from the issue thread that never made it into the docs, to reduce audio dropouts on hardware like the Raspberry Pi 3B.

Closes #164

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- Fixes #<issue number>

## Types of changes

<!--
Tick exactly one box. CI derives the label from the ticked box.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `./script/lint` passes.
- [x] `./script/tests` passes, and tests have been added/updated under `tests/` where applicable.