### PR TITLE
Restore stop word sensitivity from preferences on startup

### DIFF
--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -18,7 +18,7 @@ from getmac import get_mac_address  # type: ignore
 from pymicro_wakeword import MicroWakeWord, MicroWakeWordFeatures
 from pyopen_wakeword import OpenWakeWord, OpenWakeWordFeatures
 
-from .models import Preferences, ServerState, WakeWordType
+from .models import Preferences, ServerState, WakeWordType, initial_stop_word_threshold
 from .mpv_player import MpvMediaPlayer
 from .peripheral_api import LVAEvent, PeripheralAPIServer
 from .satellite import VoiceSatelliteProtocol
@@ -380,8 +380,8 @@ async def main() -> None:
     preferences.volume = initial_volume
 
     # Load stop word sensitivity from preferences on startup, and ensure it's between 0.0 and 1.0
-    initial_stop_word_threshold = _initial_stop_word_threshold(preferences.stop_word_sensitivity)
-    preferences.stop_word_sensitivity = initial_stop_word_threshold
+    initial_threshold = initial_stop_word_threshold(preferences.stop_word_sensitivity)
+    preferences.stop_word_sensitivity = initial_threshold
 
     if args.enable_thinking_sound:
         preferences.thinking_sound = 1
@@ -445,7 +445,7 @@ async def main() -> None:
         output_only=args.output_only,
         download_dir=args.download_dir,
         volume=initial_volume,
-        stop_word_threshold=initial_stop_word_threshold,
+        stop_word_threshold=initial_threshold,
         mic_volume=preferences.mic_volume,
         mic_auto_gain=preferences.mic_auto_gain,
         mic_noise_suppression=preferences.mic_noise_suppression,
@@ -593,18 +593,6 @@ async def main() -> None:
             await peripheral_api.stop()
 
     _LOGGER.debug("Server stopped")
-
-
-# -----------------------------------------------------------------------------
-def _initial_stop_word_threshold(saved_sensitivity: Optional[float]) -> float:
-    """
-    Resolve the stop word probability cutoff to start from, clamped to 0.0-1.0.
-    :param saved_sensitivity: Value persisted in preferences, or None if it has never been set.
-    """
-    if saved_sensitivity is None:
-        return ServerState.stop_word_threshold
-
-    return max(0.0, min(1.0, float(saved_sensitivity)))
 
 
 # -----------------------------------------------------------------------------

--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -379,6 +379,10 @@ async def main() -> None:
     initial_volume = max(0.0, min(1.0, float(initial_volume)))
     preferences.volume = initial_volume
 
+    # Load stop word sensitivity from preferences on startup, and ensure it's between 0.0 and 1.0
+    initial_stop_word_threshold = _initial_stop_word_threshold(preferences.stop_word_sensitivity)
+    preferences.stop_word_sensitivity = initial_stop_word_threshold
+
     if args.enable_thinking_sound:
         preferences.thinking_sound = 1
 
@@ -441,6 +445,7 @@ async def main() -> None:
         output_only=args.output_only,
         download_dir=args.download_dir,
         volume=initial_volume,
+        stop_word_threshold=initial_stop_word_threshold,
         mic_volume=preferences.mic_volume,
         mic_auto_gain=preferences.mic_auto_gain,
         mic_noise_suppression=preferences.mic_noise_suppression,
@@ -588,6 +593,18 @@ async def main() -> None:
             await peripheral_api.stop()
 
     _LOGGER.debug("Server stopped")
+
+
+# -----------------------------------------------------------------------------
+def _initial_stop_word_threshold(saved_sensitivity: Optional[float]) -> float:
+    """
+    Resolve the stop word probability cutoff to start from, clamped to 0.0-1.0.
+    :param saved_sensitivity: Value persisted in preferences, or None if it has never been set.
+    """
+    if saved_sensitivity is None:
+        return ServerState.stop_word_threshold
+
+    return max(0.0, min(1.0, float(saved_sensitivity)))
 
 
 # -----------------------------------------------------------------------------

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -260,3 +260,14 @@ class ServerState:
         self.preferences.mic_volume = volume_int
         _LOGGER.info("Saving mic_volume %s to %s", volume_int, self.preferences_path)
         self.save_preferences()
+
+
+def initial_stop_word_threshold(saved_sensitivity: Optional[float]) -> float:
+    """
+    Resolve the stop word probability cutoff to start from, clamped to 0.0-1.0.
+    :param saved_sensitivity: Value persisted in preferences, or None if it has never been set.
+    """
+    if saved_sensitivity is None:
+        return ServerState.stop_word_threshold
+
+    return max(0.0, min(1.0, float(saved_sensitivity)))

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -233,3 +233,31 @@ class TestPreferencesFromArgs:
         if enable_thinking_sound:
             prefs.thinking_sound = 1
         assert prefs.thinking_sound == 1
+
+
+# ---------------------------------------------------------------------------
+# Stop word sensitivity restored from preferences
+# ---------------------------------------------------------------------------
+
+
+class TestInitialStopWordThreshold:
+    def test_saved_sensitivity_is_restored(self):
+        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
+
+        assert _initial_stop_word_threshold(0.9) == pytest.approx(0.9)
+
+    def test_falls_back_to_server_state_default_when_never_set(self):
+        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
+        from linux_voice_assistant.models import ServerState
+
+        assert _initial_stop_word_threshold(None) == pytest.approx(ServerState.stop_word_threshold)
+
+    def test_clamped_to_one_when_above(self):
+        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
+
+        assert _initial_stop_word_threshold(1.5) == pytest.approx(1.0)
+
+    def test_clamped_to_zero_when_below(self):
+        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
+
+        assert _initial_stop_word_threshold(-0.5) == pytest.approx(0.0)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -233,31 +233,3 @@ class TestPreferencesFromArgs:
         if enable_thinking_sound:
             prefs.thinking_sound = 1
         assert prefs.thinking_sound == 1
-
-
-# ---------------------------------------------------------------------------
-# Stop word sensitivity restored from preferences
-# ---------------------------------------------------------------------------
-
-
-class TestInitialStopWordThreshold:
-    def test_saved_sensitivity_is_restored(self):
-        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
-
-        assert _initial_stop_word_threshold(0.9) == pytest.approx(0.9)
-
-    def test_falls_back_to_server_state_default_when_never_set(self):
-        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
-        from linux_voice_assistant.models import ServerState
-
-        assert _initial_stop_word_threshold(None) == pytest.approx(ServerState.stop_word_threshold)
-
-    def test_clamped_to_one_when_above(self):
-        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
-
-        assert _initial_stop_word_threshold(1.5) == pytest.approx(1.0)
-
-    def test_clamped_to_zero_when_below(self):
-        from linux_voice_assistant.__main__ import _initial_stop_word_threshold
-
-        assert _initial_stop_word_threshold(-0.5) == pytest.approx(0.0)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -271,3 +271,30 @@ class TestPersistMicNoise:
         with patch.object(state, "save_preferences") as mock_save:
             state.persist_mic_noise(4.0)
             mock_save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# initial_stop_word_threshold()
+# ---------------------------------------------------------------------------
+
+
+class TestInitialStopWordThreshold:
+    def test_saved_sensitivity_is_restored(self):
+        from linux_voice_assistant.models import initial_stop_word_threshold
+
+        assert initial_stop_word_threshold(0.9) == pytest.approx(0.9)
+
+    def test_falls_back_to_server_state_default_when_never_set(self):
+        from linux_voice_assistant.models import ServerState, initial_stop_word_threshold
+
+        assert initial_stop_word_threshold(None) == pytest.approx(ServerState.stop_word_threshold)
+
+    def test_clamped_to_one_when_above(self):
+        from linux_voice_assistant.models import initial_stop_word_threshold
+
+        assert initial_stop_word_threshold(1.5) == pytest.approx(1.0)
+
+    def test_clamped_to_zero_when_below(self):
+        from linux_voice_assistant.models import initial_stop_word_threshold
+
+        assert initial_stop_word_threshold(-0.5) == pytest.approx(0.0)


### PR DESCRIPTION
# What does this implement/fix?

My satellites were aborting their own replies — speech would start, then cut out
about a second in. That turned out to be the stop word firing on a single frame
over its probability cutoff, and the default of 0.5 was low enough to catch room
noise. Going to lower the sensitivity is how I found this.

`preferences.stop_word_sensitivity` is persisted whenever the number entity
changes (`satellite.py:480`), but nothing reads it back. `main()` does not pass
`stop_word_threshold` when constructing `ServerState`, so it always takes the
dataclass default of 0.5 — and `stop_word_threshold` is what the detector
actually consumes (`__main__.py:837`).

The three sensitivity setters are otherwise identical: `_set_sensitivity_1` and
`_set_sensitivity_2` both write a live field and a persisted one, and both are
restored when wake models load (`__main__.py:697-708`). `_set_stop_sensitivity`
has the same shape and is restored nowhere. The block just below that syncs all
three sensitivity entities back to Home Assistant (`__main__.py:729-733`) is
pushing a default it never loaded.

I should be upfront that I drive LVA from my own ESPHome-protocol harness rather
than Home Assistant, so I found this by reading the code, not by watching the
entity revert. I have verified the persist and reload steps work against the
real `save_preferences`/`Preferences` path — a saved 0.9 comes back as 0.9. What
is missing is only the assignment into `ServerState`.

Restored alongside `volume`, clamped the same way.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `./script/lint` passes.
- [x] `./script/tests` passes, and tests have been added/updated under `tests/` where applicable.
