### PR TITLE
Restore stop word sensitivity on startup

### DIFF
--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -409,6 +409,16 @@ async def main() -> None:
     stop_model = load_stop_model(wake_word_dirs, args.stop_model)
     assert stop_model is not None
 
+    # Load stop word sensitivity from preferences on startup, falling back to
+    # the model's own probability_cutoff rather than a fixed default.
+    initial_stop_sensitivity = (
+        preferences.stop_word_sensitivity
+        if preferences.stop_word_sensitivity is not None
+        else stop_model.probability_cutoff
+    )
+    initial_stop_sensitivity = max(0.0, min(1.0, float(initial_stop_sensitivity)))
+    preferences.stop_word_sensitivity = initial_stop_sensitivity
+
     state = ServerState(
         name=device_name,
         friendly_name=friendly_name,
@@ -423,6 +433,7 @@ async def main() -> None:
         wake_words=wake_models,
         active_wake_words=active_wake_words,
         stop_word=stop_model,
+        stop_word_threshold=initial_stop_sensitivity,
         music_player=MpvMediaPlayer(device=args.music_output_device or args.audio_output_device),
         tts_player=MpvMediaPlayer(device=args.audio_output_device),
         wakeup_sound=args.wakeup_sound,


### PR DESCRIPTION
The **Stop Word Sensitivity** number entity writes `preferences.stop_word_sensitivity`, but nothing ever reads it back, so the value returns to the default on every restart. Changing it in Home Assistant appears to work and then quietly doesn't.

The default it returns to is `ServerState.stop_word_threshold = 0.5` (`models.py:171`), which `ServerState(...)` is never given. So a stop model's own `probability_cutoff` is not applied either — a model shipped with a cutoff of `0.9` runs at `0.5`.

### Verified against `1543c5d`

Same flags and the same stop model (`probability_cutoff: 0.9`), only the patch differing:

| stored sensitivity | build | after startup |
|---|---|---|
| none | `main` | `null` — model cutoff not applied |
| none | patched | `0.9` |
| `0.85` | patched | `0.85` preserved |

The stored-value half is visible by inspection rather than by that table: nothing reads `preferences.stop_word_sensitivity`, so the restart path cannot preserve it.

### The change

Restores it the way `volume` already is a few lines above (`initial_volume`, same clamp), falling back to the model's own cutoff rather than a fixed number, and passes it to `ServerState` so the first run honours it too.

Eleven lines. No behaviour change for anyone who never touched the entity, beyond their stop model's own cutoff now taking effect.
