### PR TITLE
feat: add sensor and binary sensor entities

### DIFF
--- a/linux_voice_assistant/entity.py
+++ b/linux_voice_assistant/entity.py
@@ -838,9 +838,7 @@ class SensorEntity(ESPHomeEntity):
         self.device_class = device_class
         self.unit_of_measurement = unit_of_measurement
         self.accuracy_decimals = accuracy_decimals
-        self.state_class = int(
-            _SENSOR_STATE_CLASSES.get(state_class, SensorStateClass.MEASUREMENT)
-        )
+        self.state_class = int(_SENSOR_STATE_CLASSES.get(state_class, SensorStateClass.MEASUREMENT))
         self.icon = icon
         self._state: Optional[float] = None
         self._log = logging.getLogger(f"{self.__class__.__name__}[{self.key}]")

--- a/linux_voice_assistant/entity.py
+++ b/linux_voice_assistant/entity.py
@@ -5,15 +5,18 @@ from typing import Callable, List, Optional, Union
 
 # pylint: disable=no-name-in-module
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
+    BinarySensorStateResponse,
     EventResponse,
     LightCommandRequest,
     LightStateResponse,
+    ListEntitiesBinarySensorResponse,
     ListEntitiesEventResponse,
     ListEntitiesLightResponse,
     ListEntitiesMediaPlayerResponse,
     ListEntitiesNumberResponse,
     ListEntitiesRequest,
     ListEntitiesSelectResponse,
+    ListEntitiesSensorResponse,
     ListEntitiesSwitchResponse,
     MediaPlayerCommandRequest,
     MediaPlayerStateResponse,
@@ -21,6 +24,7 @@ from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     NumberStateResponse,
     SelectCommandRequest,
     SelectStateResponse,
+    SensorStateResponse,
     SubscribeHomeAssistantStatesRequest,
     SwitchCommandRequest,
     SwitchStateResponse,
@@ -32,6 +36,7 @@ from aioesphomeapi.model import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
     NumberMode,
+    SensorStateClass,
 )
 from google.protobuf import message
 
@@ -797,6 +802,134 @@ class ButtonEventSensorEntity(ESPHomeEntity):
         )
 
 
+_SENSOR_STATE_CLASSES = {
+    "measurement": SensorStateClass.MEASUREMENT,
+    "total": SensorStateClass.TOTAL,
+    "total_increasing": SensorStateClass.TOTAL_INCREASING,
+}
+
+
+class SensorEntity(ESPHomeEntity):
+    """Numeric Sensor entity for peripherals.
+
+    The peripheral declares a sensor via the register_sensor command
+    (device_class, unit, and so on) and pushes readings with
+    update_sensor. Generic: any peripheral can register temperature,
+    humidity, illuminance, etc., mirroring how register_light works.
+    """
+
+    def __init__(
+        self,
+        server: APIServer,
+        key: int,
+        name: str,
+        object_id: str,
+        device_class: str = "",
+        unit_of_measurement: str = "",
+        accuracy_decimals: int = 1,
+        state_class: str = "measurement",
+        icon: str = "",
+    ) -> None:
+        ESPHomeEntity.__init__(self, server)
+
+        self.key = key
+        self.name = name
+        self.object_id = object_id
+        self.device_class = device_class
+        self.unit_of_measurement = unit_of_measurement
+        self.accuracy_decimals = accuracy_decimals
+        self.state_class = int(
+            _SENSOR_STATE_CLASSES.get(state_class, SensorStateClass.MEASUREMENT)
+        )
+        self.icon = icon
+        self._state: Optional[float] = None
+        self._log = logging.getLogger(f"{self.__class__.__name__}[{self.key}]")
+
+    def update_state(self, value: float) -> None:
+        """Update the sensor with a new reading."""
+        self._state = float(value)
+        self._log.debug("Sensor state updated: %s", self._state)
+
+    def handle_message(self, msg: message.Message) -> Iterable[message.Message]:
+        if isinstance(msg, ListEntitiesRequest):
+            yield ListEntitiesSensorResponse(
+                object_id=self.object_id,
+                key=self.key,
+                name=self.name,
+                icon=self.icon,
+                unit_of_measurement=self.unit_of_measurement,
+                accuracy_decimals=self.accuracy_decimals,
+                device_class=self.device_class,
+                state_class=self.state_class,
+            )
+        elif isinstance(msg, SubscribeHomeAssistantStatesRequest):
+            # Report immediately; missing_state=True until the first reading
+            # keeps HA showing "unknown" rather than a spurious 0.
+            yield self._get_state_message()
+
+    def _get_state_message(self) -> SensorStateResponse:
+        return SensorStateResponse(
+            key=self.key,
+            state=self._state if self._state is not None else 0.0,
+            missing_state=self._state is None,
+        )
+
+
+class BinarySensorEntity(ESPHomeEntity):
+    """On/off Sensor entity for peripherals (presence, motion, etc.).
+
+    The peripheral declares a binary sensor via the register_binary_sensor
+    command and pushes readings with update_binary_sensor. Generic: any
+    peripheral can register presence, motion, occupancy, and so on,
+    mirroring how register_light works.
+    """
+
+    def __init__(
+        self,
+        server: APIServer,
+        key: int,
+        name: str,
+        object_id: str,
+        device_class: str = "",
+        icon: str = "",
+    ) -> None:
+        ESPHomeEntity.__init__(self, server)
+
+        self.key = key
+        self.name = name
+        self.object_id = object_id
+        self.device_class = device_class
+        self.icon = icon
+        self._state: Optional[bool] = None
+        self._log = logging.getLogger(f"{self.__class__.__name__}[{self.key}]")
+
+    def update_state(self, state: bool) -> None:
+        """Update the binary sensor with a new reading."""
+        self._state = bool(state)
+        self._log.debug("Binary sensor state updated: %s", self._state)
+
+    def handle_message(self, msg: message.Message) -> Iterable[message.Message]:
+        if isinstance(msg, ListEntitiesRequest):
+            yield ListEntitiesBinarySensorResponse(
+                object_id=self.object_id,
+                key=self.key,
+                name=self.name,
+                device_class=self.device_class,
+                icon=self.icon,
+            )
+        elif isinstance(msg, SubscribeHomeAssistantStatesRequest):
+            # Report immediately; missing_state=True until the first reading
+            # keeps HA showing "unknown" rather than a spurious "off".
+            yield self._get_state_message()
+
+    def _get_state_message(self) -> BinarySensorStateResponse:
+        return BinarySensorStateResponse(
+            key=self.key,
+            state=bool(self._state) if self._state is not None else False,
+            missing_state=self._state is None,
+        )
+
+
 # Backward compatibility export aliases
 __all__ = [
     "ESPHomeEntity",
@@ -805,6 +938,8 @@ __all__ = [
     "ThinkingSoundEntity",
     "LEDLightEntity",
     "ButtonEventSensorEntity",
+    "SensorEntity",
+    "BinarySensorEntity",
     "WakeWord1SensitivityNumberEntity",
     "WakeWord2SensitivityNumberEntity",
     "StopWordSensitivityNumberEntity",

--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -15,12 +15,14 @@ if TYPE_CHECKING:
     from pyopen_wakeword import OpenWakeWord
 
     from .entity import (
+        BinarySensorEntity,
         ButtonEventSensorEntity,
         ESPHomeEntity,
         LEDLightEntity,
         MediaPlayerEntity,
         MicSettingEntity,
         MuteSwitchEntity,
+        SensorEntity,
         StopWordSensitivityNumberEntity,
         ThinkingSoundEntity,
         WakeWord1SensitivityNumberEntity,
@@ -78,6 +80,41 @@ class LightRegistration:
     effects: List[str] = field(default_factory=list)
     supports_rgb: bool = True
     supports_brightness: bool = True
+
+
+@dataclass
+class SensorRegistration:
+    """Capabilities a peripheral declares for one of its Sensor entities.
+
+    The peripheral sends this with the register_sensor command after
+    connecting. LVA materialises a matching SensorEntity so HA can
+    display it. Generic: any peripheral can register temperature,
+    humidity, illuminance, and so on.
+    """
+
+    name: str
+    object_id: str
+    device_class: str = ""
+    unit_of_measurement: str = ""
+    accuracy_decimals: int = 1
+    state_class: str = "measurement"
+    icon: str = ""
+
+
+@dataclass
+class BinarySensorRegistration:
+    """Capabilities a peripheral declares for one of its Binary Sensor entities.
+
+    The peripheral sends this with the register_binary_sensor command after
+    connecting. LVA materialises a matching BinarySensorEntity so HA can
+    display it. Generic: any peripheral can register presence, motion,
+    occupancy, and so on.
+    """
+
+    name: str
+    object_id: str
+    device_class: str = ""
+    icon: str = ""
 
 
 @dataclass
@@ -139,6 +176,21 @@ class ServerState:
     # Materialised LightEntities keyed by object_id, so light_command
     # events can be routed back to the right peripheral hardware.
     led_light_entities: "Dict[str, LEDLightEntity]" = field(default_factory=dict)
+
+    # Sensors declared by peripherals via register_sensor. Survives HA
+    # reconnects so the satellite can rebuild its entities whenever it is
+    # constructed again.
+    pending_sensors: "List[SensorRegistration]" = field(default_factory=list)
+    # Materialised SensorEntities keyed by object_id, so update_sensor
+    # readings can be routed to the right entity.
+    sensor_entities: "Dict[str, SensorEntity]" = field(default_factory=dict)
+
+    # Binary sensors declared by peripherals via register_binary_sensor.
+    # Survives HA reconnects, mirroring pending_sensors.
+    pending_binary_sensors: "List[BinarySensorRegistration]" = field(default_factory=list)
+    # Materialised BinarySensorEntities keyed by object_id, so
+    # update_binary_sensor readings can be routed to the right entity.
+    binary_sensor_entities: "Dict[str, BinarySensorEntity]" = field(default_factory=dict)
 
     # True once a peripheral sends register_button. Gates creation of
     # ButtonEventSensorEntity so the HA device page only shows the button

--- a/linux_voice_assistant/peripheral_api.py
+++ b/linux_voice_assistant/peripheral_api.py
@@ -92,6 +92,30 @@ Commands accepted from the peripheral container
               events to Home Assistant when the corresponding
               button_* commands are sent. Send once after connecting;
               duplicate registrations are ignored.
+  register_sensor   data: {"name": str, "object_id": str,
+                           "device_class": str, "unit_of_measurement": str,
+                           "accuracy_decimals": int, "state_class": str,
+                           "icon": str}
+              The peripheral declares a numeric Sensor it wants exposed
+              in HA. LVA creates a matching ESPHome Sensor entity
+              (visible as sensor.<satellite>_<object_id>). Generic: any
+              peripheral can register temperature, humidity, illuminance,
+              etc. Send once after connecting; duplicate registrations
+              for the same object_id are ignored.
+  update_sensor     data: {"object_id": str, "state": float}
+              Push a new reading for a previously registered Sensor. LVA
+              forwards it to Home Assistant.
+  register_binary_sensor  data: {"name": str, "object_id": str,
+                           "device_class": str, "icon": str}
+              The peripheral declares an on/off Binary Sensor it wants
+              exposed in HA. LVA creates a matching ESPHome Binary Sensor
+              entity (visible as binary_sensor.<satellite>_<object_id>).
+              Generic: any peripheral can register presence, motion,
+              occupancy, etc. Send once after connecting; duplicate
+              registrations for the same object_id are ignored.
+  update_binary_sensor  data: {"object_id": str, "state": bool}
+              Push a new reading for a previously registered Binary Sensor.
+              LVA forwards it to Home Assistant.
 """
 
 from __future__ import annotations
@@ -161,6 +185,21 @@ class LVACommand(str, Enum):
     BUTTON_LONG_PRESS = "button_long_press"
     REGISTER_LIGHT = "register_light"
     REGISTER_BUTTON = "register_button"
+    REGISTER_SENSOR = "register_sensor"
+    UPDATE_SENSOR = "update_sensor"
+    REGISTER_BINARY_SENSOR = "register_binary_sensor"
+    UPDATE_BINARY_SENSOR = "update_binary_sensor"
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Coerce a JSON-decoded value to a bool.
+
+    Accepts real booleans, numbers (1/0), and common truthy strings so a
+    peripheral can send whatever its language marshals naturally.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "on", "yes")
+    return bool(value)
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +519,18 @@ class PeripheralAPIServer:
         elif command == LVACommand.REGISTER_BUTTON:
             self._register_button(satellite)
 
+        elif command == LVACommand.REGISTER_SENSOR:
+            self._register_sensor(msg.get("data") or {}, satellite)
+
+        elif command == LVACommand.UPDATE_SENSOR:
+            self._update_sensor(msg.get("data") or {}, satellite)
+
+        elif command == LVACommand.REGISTER_BINARY_SENSOR:
+            self._register_binary_sensor(msg.get("data") or {}, satellite)
+
+        elif command == LVACommand.UPDATE_BINARY_SENSOR:
+            self._update_binary_sensor(msg.get("data") or {}, satellite)
+
     def _register_light(self, data: Dict[str, Any], satellite: Any) -> None:
         """Register a Light declared by a peripheral.
 
@@ -548,6 +599,149 @@ class PeripheralAPIServer:
             satellite.register_pending_button()
 
         self._schedule_ha_reconnect_for_late_entity("button", "button_press_event")
+
+    def _register_sensor(self, data: Dict[str, Any], satellite: Any) -> None:
+        """Register a Sensor declared by a peripheral.
+
+        Idempotent on object_id: repeat registrations (e.g. after a
+        peripheral reconnect) keep the existing entity and its state.
+        Generic — any peripheral can declare temperature, humidity,
+        illuminance, etc., mirroring register_light.
+        """
+        from .models import SensorRegistration  # local import to avoid a cycle
+
+        object_id = str(data.get("object_id", "")).strip()
+        if not object_id:
+            _LOGGER.warning("register_sensor without object_id; ignoring")
+            return
+
+        state = self._state
+        if state is None:
+            return
+
+        if any(spec.object_id == object_id for spec in state.pending_sensors):
+            # Same sensor already on file; nothing to do.
+            return
+
+        spec = SensorRegistration(
+            name=str(data.get("name", "Sensor")),
+            object_id=object_id,
+            device_class=str(data.get("device_class", "")),
+            unit_of_measurement=str(data.get("unit_of_measurement", "")),
+            accuracy_decimals=int(data.get("accuracy_decimals", 1)),
+            state_class=str(data.get("state_class", "measurement")),
+            icon=str(data.get("icon", "")),
+        )
+        state.pending_sensors.append(spec)
+        _LOGGER.info(
+            "Sensor registered: %s (device_class=%s)", object_id, spec.device_class
+        )
+
+        # If the satellite is already running, materialise the entity now so
+        # future readings route correctly. HA only sees it after the
+        # integration reconnects, but LVA stays consistent.
+        if satellite is not None:
+            satellite.register_pending_sensors()
+
+        self._schedule_ha_reconnect_for_late_entity("sensor", object_id)
+
+    def _update_sensor(self, data: Dict[str, Any], satellite: Any) -> None:
+        """Apply a new reading to a peripheral-registered Sensor and push it to HA."""
+        object_id = str(data.get("object_id", "")).strip()
+        if not object_id:
+            _LOGGER.warning("update_sensor without object_id; ignoring")
+            return
+
+        state = self._state
+        if state is None:
+            return
+
+        entity = state.sensor_entities.get(object_id)
+        if entity is None:
+            _LOGGER.warning("update_sensor for unknown sensor '%s'; ignoring", object_id)
+            return
+
+        if "state" not in data:
+            return
+
+        try:
+            value = float(data["state"])
+        except (TypeError, ValueError):
+            _LOGGER.warning("update_sensor '%s' with non-numeric state; ignoring", object_id)
+            return
+
+        entity.update_state(value)
+        if satellite is not None:
+            # pylint: disable=protected-access
+            satellite.send_messages([entity._get_state_message()])
+
+    def _register_binary_sensor(self, data: Dict[str, Any], satellite: Any) -> None:
+        """Register a Binary Sensor declared by a peripheral.
+
+        Idempotent on object_id: repeat registrations (e.g. after a
+        peripheral reconnect) keep the existing entity and its state.
+        Generic — any peripheral can declare presence, motion, occupancy,
+        etc., mirroring register_sensor.
+        """
+        from .models import BinarySensorRegistration  # local import to avoid a cycle
+
+        object_id = str(data.get("object_id", "")).strip()
+        if not object_id:
+            _LOGGER.warning("register_binary_sensor without object_id; ignoring")
+            return
+
+        state = self._state
+        if state is None:
+            return
+
+        if any(spec.object_id == object_id for spec in state.pending_binary_sensors):
+            # Same binary sensor already on file; nothing to do.
+            return
+
+        spec = BinarySensorRegistration(
+            name=str(data.get("name", "Binary Sensor")),
+            object_id=object_id,
+            device_class=str(data.get("device_class", "")),
+            icon=str(data.get("icon", "")),
+        )
+        state.pending_binary_sensors.append(spec)
+        _LOGGER.info(
+            "Binary sensor registered: %s (device_class=%s)", object_id, spec.device_class
+        )
+
+        # If the satellite is already running, materialise the entity now so
+        # future readings route correctly. HA only sees it after the
+        # integration reconnects, but LVA stays consistent.
+        if satellite is not None:
+            satellite.register_pending_binary_sensors()
+
+        self._schedule_ha_reconnect_for_late_entity("binary_sensor", object_id)
+
+    def _update_binary_sensor(self, data: Dict[str, Any], satellite: Any) -> None:
+        """Apply a new reading to a peripheral-registered Binary Sensor and push it to HA."""
+        object_id = str(data.get("object_id", "")).strip()
+        if not object_id:
+            _LOGGER.warning("update_binary_sensor without object_id; ignoring")
+            return
+
+        state = self._state
+        if state is None:
+            return
+
+        entity = state.binary_sensor_entities.get(object_id)
+        if entity is None:
+            _LOGGER.warning(
+                "update_binary_sensor for unknown binary sensor '%s'; ignoring", object_id
+            )
+            return
+
+        if "state" not in data:
+            return
+
+        entity.update_state(_coerce_bool(data["state"]))
+        if satellite is not None:
+            # pylint: disable=protected-access
+            satellite.send_messages([entity._get_state_message()])
 
     # ------------------------------------------------------------------
     # Helpers

--- a/linux_voice_assistant/peripheral_api.py
+++ b/linux_voice_assistant/peripheral_api.py
@@ -633,9 +633,7 @@ class PeripheralAPIServer:
             icon=str(data.get("icon", "")),
         )
         state.pending_sensors.append(spec)
-        _LOGGER.info(
-            "Sensor registered: %s (device_class=%s)", object_id, spec.device_class
-        )
+        _LOGGER.info("Sensor registered: %s (device_class=%s)", object_id, spec.device_class)
 
         # If the satellite is already running, materialise the entity now so
         # future readings route correctly. HA only sees it after the
@@ -705,9 +703,7 @@ class PeripheralAPIServer:
             icon=str(data.get("icon", "")),
         )
         state.pending_binary_sensors.append(spec)
-        _LOGGER.info(
-            "Binary sensor registered: %s (device_class=%s)", object_id, spec.device_class
-        )
+        _LOGGER.info("Binary sensor registered: %s (device_class=%s)", object_id, spec.device_class)
 
         # If the satellite is already running, materialise the entity now so
         # future readings route correctly. HA only sees it after the
@@ -730,9 +726,7 @@ class PeripheralAPIServer:
 
         entity = state.binary_sensor_entities.get(object_id)
         if entity is None:
-            _LOGGER.warning(
-                "update_binary_sensor for unknown binary sensor '%s'; ignoring", object_id
-            )
+            _LOGGER.warning("update_binary_sensor for unknown binary sensor '%s'; ignoring", object_id)
             return
 
         if "state" not in data:

--- a/linux_voice_assistant/satellite.py
+++ b/linux_voice_assistant/satellite.py
@@ -51,11 +51,13 @@ from pyopen_wakeword import OpenWakeWord
 
 from .api_server import APIServer
 from .entity import (
+    BinarySensorEntity,
     ButtonEventSensorEntity,
     LEDLightEntity,
     MediaPlayerEntity,
     MicSettingEntity,
     MuteSwitchEntity,
+    SensorEntity,
     StopWordSensitivityNumberEntity,
     ThinkingSoundEntity,
     WakeWord1SensitivityNumberEntity,
@@ -335,6 +337,12 @@ class VoiceSatelliteProtocol(APIServer):
         # button support before this satellite was constructed (e.g. on an HA
         # reconnect while the peripheral container stayed connected to LVA).
         self.register_pending_button()
+        # Materialise the Sensor entities peripherals registered before this
+        # satellite was constructed (or reattach existing ones).
+        self.register_pending_sensors()
+        # Materialise the Binary Sensor entities peripherals registered before
+        # this satellite was constructed (or reattach existing ones).
+        self.register_pending_binary_sensors()
 
         # ---- Instance variables ----
 
@@ -430,6 +438,69 @@ class VoiceSatelliteProtocol(APIServer):
         self.state.entities.append(entity)
         self.state.button_event_sensor_entity = entity
         _LOGGER.info("Button event sensor entity materialised")
+
+    def register_pending_sensors(self) -> None:
+        """Materialise SensorEntities for peripheral registered sensors.
+
+        Mirrors register_pending_lights: called from __init__ so entities
+        exist by the time HA enumerates, and again from the peripheral_api
+        dispatcher when a sensor arrives after the satellite is already
+        running. HA only sees a late registration after its next reconnect,
+        but LVA stays consistent.
+        """
+        for spec in self.state.pending_sensors:
+            if spec.object_id in self.state.sensor_entities:
+                # Already materialised. Reattach the server in case the
+                # satellite has been reconstructed (HA reconnect).
+                self.state.sensor_entities[spec.object_id].server = self
+                if self.state.sensor_entities[spec.object_id] not in self.state.entities:
+                    self.state.entities.append(self.state.sensor_entities[spec.object_id])
+                continue
+
+            object_id = spec.object_id
+            entity = SensorEntity(
+                server=self,
+                key=len(self.state.entities),
+                name=spec.name,
+                object_id=object_id,
+                device_class=spec.device_class,
+                unit_of_measurement=spec.unit_of_measurement,
+                accuracy_decimals=spec.accuracy_decimals,
+                state_class=spec.state_class,
+                icon=spec.icon,
+            )
+            self.state.entities.append(entity)
+            self.state.sensor_entities[object_id] = entity
+
+    def register_pending_binary_sensors(self) -> None:
+        """Materialise BinarySensorEntities for peripheral registered binary sensors.
+
+        Mirrors register_pending_lights: called from __init__ so entities
+        exist by the time HA enumerates, and again from the peripheral_api
+        dispatcher when a binary sensor arrives after the satellite is already
+        running. HA only sees a late registration after its next reconnect,
+        but LVA stays consistent.
+        """
+        for spec in self.state.pending_binary_sensors:
+            if spec.object_id in self.state.binary_sensor_entities:
+                # Already materialised. Reattach the server in case the
+                # satellite has been reconstructed (HA reconnect).
+                self.state.binary_sensor_entities[spec.object_id].server = self
+                if self.state.binary_sensor_entities[spec.object_id] not in self.state.entities:
+                    self.state.entities.append(self.state.binary_sensor_entities[spec.object_id])
+                continue
+
+            object_id = spec.object_id
+            entity = BinarySensorEntity(
+                server=self,
+                key=len(self.state.entities),
+                name=spec.name,
+                object_id=object_id,
+                device_class=spec.device_class,
+                icon=spec.icon,
+            )
+            self.state.entities.append(entity)
+            self.state.binary_sensor_entities[object_id] = entity
 
     def _on_led_light_changed(self, object_id: str) -> None:
         """Forward an HA Light entity change to peripherals as light_command.

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -3,10 +3,13 @@
 from unittest.mock import MagicMock
 
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
+    BinarySensorStateResponse,
+    ListEntitiesBinarySensorResponse,
     ListEntitiesMediaPlayerResponse,
     ListEntitiesNumberResponse,
     ListEntitiesRequest,
     ListEntitiesSelectResponse,
+    ListEntitiesSensorResponse,
     ListEntitiesSwitchResponse,
     MediaPlayerCommandRequest,
     MediaPlayerStateResponse,
@@ -14,6 +17,7 @@ from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     NumberStateResponse,
     SelectCommandRequest,
     SelectStateResponse,
+    SensorStateResponse,
     SubscribeHomeAssistantStatesRequest,
     SwitchCommandRequest,
     SwitchStateResponse,
@@ -64,6 +68,37 @@ def make_mute_switch(server=None, key=2, initial_muted=False):
     entity._get_muted = get_muted
     entity._set_muted = set_muted
     return entity
+
+
+def make_sensor(server=None, key=10, **kwargs):
+    from linux_voice_assistant.entity import SensorEntity
+
+    server = server or make_server()
+    params = dict(
+        name="Temperature",
+        object_id="temperature",
+        device_class="temperature",
+        unit_of_measurement="°C",
+        accuracy_decimals=1,
+        state_class="measurement",
+        icon="mdi:thermometer",
+    )
+    params.update(kwargs)
+    return SensorEntity(server=server, key=key, **params)
+
+
+def make_binary_sensor(server=None, key=11, **kwargs):
+    from linux_voice_assistant.entity import BinarySensorEntity
+
+    server = server or make_server()
+    params = dict(
+        name="Presence",
+        object_id="presence",
+        device_class="occupancy",
+        icon="mdi:motion-sensor",
+    )
+    params.update(kwargs)
+    return BinarySensorEntity(server=server, key=key, **params)
 
 
 def make_mic_setting(server=None, key=3, options=None, value=0.0):
@@ -422,3 +457,155 @@ class TestMicSettingEntitySelect:
         msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
         select_msg = next(m for m in msgs if isinstance(m, SelectStateResponse))
         assert isinstance(select_msg.state, str)
+
+
+# ---------------------------------------------------------------------------
+# SensorEntity
+# ---------------------------------------------------------------------------
+
+
+class TestSensorEntityListEntities:
+    def test_list_entities_request_yields_response(self):
+        entity = make_sensor(key=10)
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], ListEntitiesSensorResponse)
+
+    def test_list_entities_response_has_correct_key(self):
+        entity = make_sensor(key=10)
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].key == 10
+
+    def test_list_entities_response_has_correct_object_id(self):
+        entity = make_sensor()
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].object_id == "temperature"
+
+    def test_list_entities_response_has_device_class(self):
+        entity = make_sensor(device_class="humidity")
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].device_class == "humidity"
+
+    def test_list_entities_response_has_unit(self):
+        entity = make_sensor(unit_of_measurement="%")
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].unit_of_measurement == "%"
+
+    def test_list_entities_response_has_accuracy(self):
+        entity = make_sensor(accuracy_decimals=2)
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].accuracy_decimals == 2
+
+
+class TestSensorEntityStateClass:
+    def test_measurement_maps_to_one(self):
+        entity = make_sensor(state_class="measurement")
+        assert entity.state_class == 1
+
+    def test_total_increasing_maps_to_two(self):
+        entity = make_sensor(state_class="total_increasing")
+        assert entity.state_class == 2
+
+    def test_total_maps_to_three(self):
+        entity = make_sensor(state_class="total")
+        assert entity.state_class == 3
+
+    def test_unknown_defaults_to_measurement(self):
+        entity = make_sensor(state_class="bogus")
+        assert entity.state_class == 1
+
+
+class TestSensorEntityState:
+    def test_missing_state_before_first_reading(self):
+        entity = make_sensor()
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert msgs[0].missing_state is True
+
+    def test_subscribe_states_yields_sensor_state_response(self):
+        entity = make_sensor()
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert isinstance(msgs[0], SensorStateResponse)
+
+    def test_update_state_stores_value(self):
+        entity = make_sensor()
+        entity.update_state(21.4)
+        assert abs(entity._state - 21.4) < 0.001
+
+    def test_state_reported_after_update(self):
+        entity = make_sensor()
+        entity.update_state(21.4)
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert msgs[0].missing_state is False
+        assert abs(msgs[0].state - 21.4) < 0.001
+
+    def test_get_state_message_has_correct_key(self):
+        entity = make_sensor(key=12)
+        entity.update_state(1.0)
+        assert entity._get_state_message().key == 12
+
+
+# ---------------------------------------------------------------------------
+# BinarySensorEntity
+# ---------------------------------------------------------------------------
+
+
+class TestBinarySensorEntityListEntities:
+    def test_list_entities_request_yields_response(self):
+        entity = make_binary_sensor(key=11)
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], ListEntitiesBinarySensorResponse)
+
+    def test_list_entities_response_has_correct_key(self):
+        entity = make_binary_sensor(key=11)
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].key == 11
+
+    def test_list_entities_response_has_correct_object_id(self):
+        entity = make_binary_sensor()
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].object_id == "presence"
+
+    def test_list_entities_response_has_device_class(self):
+        entity = make_binary_sensor(device_class="motion")
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].device_class == "motion"
+
+    def test_list_entities_response_has_icon(self):
+        entity = make_binary_sensor(icon="mdi:run")
+        msgs = list(entity.handle_message(ListEntitiesRequest()))
+        assert msgs[0].icon == "mdi:run"
+
+
+class TestBinarySensorEntityState:
+    def test_missing_state_before_first_reading(self):
+        entity = make_binary_sensor()
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert msgs[0].missing_state is True
+
+    def test_subscribe_states_yields_binary_sensor_state_response(self):
+        entity = make_binary_sensor()
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert isinstance(msgs[0], BinarySensorStateResponse)
+
+    def test_update_state_stores_value(self):
+        entity = make_binary_sensor()
+        entity.update_state(True)
+        assert entity._state is True
+
+    def test_state_reported_after_update(self):
+        entity = make_binary_sensor()
+        entity.update_state(True)
+        msgs = list(entity.handle_message(SubscribeHomeAssistantStatesRequest()))
+        assert msgs[0].missing_state is False
+        assert msgs[0].state is True
+
+    def test_update_state_coerces_to_bool(self):
+        entity = make_binary_sensor()
+        entity.update_state(0)
+        assert entity._state is False
+
+    def test_get_state_message_has_correct_key(self):
+        entity = make_binary_sensor(key=13)
+        entity.update_state(True)
+        assert entity._get_state_message().key == 13

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,6 +14,22 @@ def make_preferences(**kwargs):
     return Preferences(**kwargs)
 
 
+def make_sensor_registration(**kwargs):
+    from linux_voice_assistant.models import SensorRegistration
+
+    params = dict(name="Temperature", object_id="temperature")
+    params.update(kwargs)
+    return SensorRegistration(**params)
+
+
+def make_binary_sensor_registration(**kwargs):
+    from linux_voice_assistant.models import BinarySensorRegistration
+
+    params = dict(name="Presence", object_id="presence")
+    params.update(kwargs)
+    return BinarySensorRegistration(**params)
+
+
 # ---------------------------------------------------------------------------
 # WakeWordType
 # ---------------------------------------------------------------------------
@@ -271,3 +287,119 @@ class TestPersistMicNoise:
         with patch.object(state, "save_preferences") as mock_save:
             state.persist_mic_noise(4.0)
             mock_save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SensorRegistration
+# ---------------------------------------------------------------------------
+
+
+class TestSensorRegistration:
+    def test_required_fields_stored(self):
+        reg = make_sensor_registration(name="Humidity", object_id="humidity")
+        assert reg.name == "Humidity"
+        assert reg.object_id == "humidity"
+
+    def test_default_device_class_is_empty(self):
+        reg = make_sensor_registration()
+        assert reg.device_class == ""
+
+    def test_default_unit_is_empty(self):
+        reg = make_sensor_registration()
+        assert reg.unit_of_measurement == ""
+
+    def test_default_accuracy_is_one(self):
+        reg = make_sensor_registration()
+        assert reg.accuracy_decimals == 1
+
+    def test_default_state_class_is_measurement(self):
+        reg = make_sensor_registration()
+        assert reg.state_class == "measurement"
+
+    def test_default_icon_is_empty(self):
+        reg = make_sensor_registration()
+        assert reg.icon == ""
+
+    def test_custom_values_stored(self):
+        reg = make_sensor_registration(
+            device_class="humidity",
+            unit_of_measurement="%",
+            accuracy_decimals=0,
+            icon="mdi:water-percent",
+        )
+        assert reg.device_class == "humidity"
+        assert reg.unit_of_measurement == "%"
+        assert reg.accuracy_decimals == 0
+        assert reg.icon == "mdi:water-percent"
+
+
+# ---------------------------------------------------------------------------
+# ServerState sensor fields
+# ---------------------------------------------------------------------------
+
+
+class TestServerStateSensors:
+    def test_pending_sensors_defaults_empty(self, tmp_path):
+        state = make_server_state(tmp_path)
+        assert state.pending_sensors == []
+
+    def test_sensor_entities_defaults_empty(self, tmp_path):
+        state = make_server_state(tmp_path)
+        assert state.sensor_entities == {}
+
+    def test_pending_sensors_independent_per_instance(self, tmp_path):
+        """Mutable default must not be shared between instances."""
+        state1 = make_server_state(tmp_path)
+        state2 = make_server_state(tmp_path)
+        state1.pending_sensors.append(make_sensor_registration())
+        assert state2.pending_sensors == []
+
+
+# ---------------------------------------------------------------------------
+# BinarySensorRegistration
+# ---------------------------------------------------------------------------
+
+
+class TestBinarySensorRegistration:
+    def test_required_fields_stored(self):
+        reg = make_binary_sensor_registration(name="Motion", object_id="motion")
+        assert reg.name == "Motion"
+        assert reg.object_id == "motion"
+
+    def test_default_device_class_is_empty(self):
+        reg = make_binary_sensor_registration()
+        assert reg.device_class == ""
+
+    def test_default_icon_is_empty(self):
+        reg = make_binary_sensor_registration()
+        assert reg.icon == ""
+
+    def test_custom_values_stored(self):
+        reg = make_binary_sensor_registration(
+            device_class="occupancy",
+            icon="mdi:motion-sensor",
+        )
+        assert reg.device_class == "occupancy"
+        assert reg.icon == "mdi:motion-sensor"
+
+
+# ---------------------------------------------------------------------------
+# ServerState binary sensor fields
+# ---------------------------------------------------------------------------
+
+
+class TestServerStateBinarySensors:
+    def test_pending_binary_sensors_defaults_empty(self, tmp_path):
+        state = make_server_state(tmp_path)
+        assert state.pending_binary_sensors == []
+
+    def test_binary_sensor_entities_defaults_empty(self, tmp_path):
+        state = make_server_state(tmp_path)
+        assert state.binary_sensor_entities == {}
+
+    def test_pending_binary_sensors_independent_per_instance(self, tmp_path):
+        """Mutable default must not be shared between instances."""
+        state1 = make_server_state(tmp_path)
+        state2 = make_server_state(tmp_path)
+        state1.pending_binary_sensors.append(make_binary_sensor_registration())
+        assert state2.pending_binary_sensors == []

--- a/tests/unit/test_satellite.py
+++ b/tests/unit/test_satellite.py
@@ -367,3 +367,129 @@ class TestConnectionLost:
         sat = make_satellite(tmp_path)
         sat.connection_lost(None)
         sat.state.tts_player.stop.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# register_pending_sensors()
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPendingSensors:
+    def _add_pending(self, sat, object_id="temperature", name="Temperature"):
+        from linux_voice_assistant.models import SensorRegistration
+
+        sat.state.pending_sensors.append(
+            SensorRegistration(
+                name=name,
+                object_id=object_id,
+                device_class="temperature",
+                unit_of_measurement="°C",
+            )
+        )
+
+    def test_materialises_sensor_entity(self, tmp_path):
+        from linux_voice_assistant.entity import SensorEntity
+
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_sensors()
+        assert isinstance(sat.state.sensor_entities.get("temperature"), SensorEntity)
+
+    def test_entity_added_to_entities_list(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_sensors()
+        assert sat.state.sensor_entities["temperature"] in sat.state.entities
+
+    def test_entity_carries_registration_fields(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_sensors()
+        entity = sat.state.sensor_entities["temperature"]
+        assert entity.device_class == "temperature"
+        assert entity.unit_of_measurement == "°C"
+
+    def test_idempotent_keeps_same_entity(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_sensors()
+        first = sat.state.sensor_entities["temperature"]
+        sat.register_pending_sensors()
+        assert sat.state.sensor_entities["temperature"] is first
+
+    def test_idempotent_no_duplicate_in_entities(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_sensors()
+        entity = sat.state.sensor_entities["temperature"]
+        sat.register_pending_sensors()
+        assert sat.state.entities.count(entity) == 1
+
+    def test_no_pending_creates_nothing(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        sat.state.pending_sensors.clear()
+        sat.state.sensor_entities.clear()
+        sat.register_pending_sensors()
+        assert sat.state.sensor_entities == {}
+
+
+# ---------------------------------------------------------------------------
+# register_pending_binary_sensors()
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPendingBinarySensors:
+    def _add_pending(self, sat, object_id="presence", name="Presence"):
+        from linux_voice_assistant.models import BinarySensorRegistration
+
+        sat.state.pending_binary_sensors.append(
+            BinarySensorRegistration(
+                name=name,
+                object_id=object_id,
+                device_class="occupancy",
+            )
+        )
+
+    def test_materialises_binary_sensor_entity(self, tmp_path):
+        from linux_voice_assistant.entity import BinarySensorEntity
+
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_binary_sensors()
+        assert isinstance(sat.state.binary_sensor_entities.get("presence"), BinarySensorEntity)
+
+    def test_entity_added_to_entities_list(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_binary_sensors()
+        assert sat.state.binary_sensor_entities["presence"] in sat.state.entities
+
+    def test_entity_carries_registration_fields(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_binary_sensors()
+        entity = sat.state.binary_sensor_entities["presence"]
+        assert entity.device_class == "occupancy"
+
+    def test_idempotent_keeps_same_entity(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_binary_sensors()
+        first = sat.state.binary_sensor_entities["presence"]
+        sat.register_pending_binary_sensors()
+        assert sat.state.binary_sensor_entities["presence"] is first
+
+    def test_idempotent_no_duplicate_in_entities(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        self._add_pending(sat)
+        sat.register_pending_binary_sensors()
+        entity = sat.state.binary_sensor_entities["presence"]
+        sat.register_pending_binary_sensors()
+        assert sat.state.entities.count(entity) == 1
+
+    def test_no_pending_creates_nothing(self, tmp_path):
+        sat = make_satellite(tmp_path)
+        sat.state.pending_binary_sensors.clear()
+        sat.state.binary_sensor_entities.clear()
+        sat.register_pending_binary_sensors()
+        assert sat.state.binary_sensor_entities == {}


### PR DESCRIPTION
# Summary

Adding sensor and binary sensor entities and peripheral API so that devices that provide sensor data can push the data to Home Assistant. For example the Satellite1 HAT has a temperature, humidity, lux and optional mmWave presence sensor. These can be useful for automations in Home Assistant where the smart speaker is present.

This was tested on a Satellite1 HAT and LD2450 mmWave sensor with a Pi Zero 2 W (screenshot included)

<img width="335" height="722" alt="Screenshot 2026-08-06 at 23 08 48" src="https://github.com/user-attachments/assets/ec100933-0570-45ef-8413-c0e0527a5c36" />

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `./script/lint` passes.
- [x] `./script/tests` passes, and tests have been added/updated under `tests/` where applicable.