### PR TITLE
Skip wake word scoring while a pipeline/response is active

### DIFF
--- a/linux_voice_assistant/__main__.py
+++ b/linux_voice_assistant/__main__.py
@@ -771,7 +771,19 @@ def process_audio(state: ServerState, mic, block_size: int):
                         oww_inputs.clear()
                         oww_inputs.extend(oww_features.process_streaming(audio_chunk))
 
+                    pipeline_active = bool(state.satellite and getattr(state.satellite, "_pipeline_active", False))
                     for wake_word_index, wake_word in enumerate(wake_words):
+                        if pipeline_active:
+                            # A response (or an already-active pipeline run) is in
+                            # progress. Skip wake word scoring entirely instead of
+                            # only filtering the result in Satellite.wakeup() - the
+                            # device's own TTS audio scores as a near-certain match
+                            # for its own wake word (residual echo, no AEC), so this
+                            # avoids needless inference and the narrow race where a
+                            # fresh detection lands just after REFRACTORY_SECONDS
+                            # elapses but before playback has actually finished.
+                            continue
+
                         activated = False
 
                         # Set dynamic threshold depending on wake word index


### PR DESCRIPTION
## Summary
- `Satellite.wakeup()` already ignores wake word detections while `self._pipeline_active` is `True` (logged as "Ignoring wake word - pipeline already active"), but the wake word models keep running inference on every audio frame during that window regardless, including throughout TTS playback.
- On hardware without working AEC, a satellite's own TTS output reliably scores as a near-certain match for its own wake word (residual echo picked up by the mic) - in real-world testing I saw probabilities of 0.9+ throughout entire responses, well above the configured threshold.
- `wakeup()` correctly catches this today, but only after the fact. There's also a narrow window right after `REFRACTORY_SECONDS` elapses mid-response (before `_pipeline_active` clears) where a fresh detection depends entirely on that one guard.
- This moves the check to the source: skip wake word scoring for the primary wake words while a pipeline/response is already active, matching the intent already documented in `satellite.py`:
  > "When TTS is playing, keep `_pipeline_active` = True to block false wake word detections from speaker audio feedback."
- Stop word detection is a separate code path and is unaffected - it still needs to run while a response is in progress.

## Test plan
- [x] `./script/lint_black`, `./script/lint_isort`, `./script/lint_flake8` clean on the changed file (couldn't run the full `./script/tests` suite locally - missing `libmpv-dev` system dependency in my sandbox, not something I could install there)
- [x] Deployed to 5 real satellites (Raspberry Pi, ReSpeaker 2-Mic HAT) running microWakeWord, confirmed no probability-log lines for the primary wake words during active playback afterwards, containers stayed healthy
- [ ] Would appreciate a maintainer/CI run of the full test suite given I couldn't run it myself

🤖 Filed with the help of [Claude Code](https://claude.com/claude-code), reviewed and approved by me before submission.