### PR TITLE
Set id on loaded openWakeWord models

### DIFF
--- a/linux_voice_assistant/models.py
+++ b/linux_voice_assistant/models.py
@@ -56,6 +56,9 @@ class AvailableWakeWord:
             from pyopen_wakeword import OpenWakeWord
 
             oww_model = OpenWakeWord.from_model(model_path=self.wake_word_path)
+            # pyopen_wakeword derives .id from the model filename, but callers
+            # match against the manifest id this was loaded under.
+            setattr(oww_model, "id", self.id)
             setattr(oww_model, "wake_word", self.wake_word)
 
             return oww_model

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,6 +1,7 @@
 """Unit tests for shared models."""
 
 import json
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -309,3 +310,49 @@ class TestInitialStopWordThreshold:
         from linux_voice_assistant.models import initial_stop_word_threshold
 
         assert initial_stop_word_threshold(-0.5) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# AvailableWakeWord.load()
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenWakeWord:
+    """Stands in for pyopen_wakeword's model, which derives ``id`` from the filename."""
+
+    @classmethod
+    def from_model(cls, model_path):
+        model = cls()
+        model.id = Path(model_path).stem
+        return model
+
+
+def make_available_oww(model_id: str, model_file: str, wake_word: str = "Ok Nabu (OWW)"):
+    from linux_voice_assistant.models import AvailableWakeWord, WakeWordType
+
+    return AvailableWakeWord(
+        id=model_id,
+        type=WakeWordType.OPEN_WAKE_WORD,
+        wake_word=wake_word,
+        trained_languages=["en"],
+        wake_word_path=Path("/mock/wakewords") / model_file,
+    )
+
+
+class TestAvailableWakeWordLoad:
+    def test_oww_id_comes_from_the_manifest_not_the_filename(self):
+        """Detection matches on model.id, so it must be the id the model is stored under."""
+        available = make_available_oww("okay_nabu_oww", "ok_nabu_v0.1.tflite")
+
+        with patch("pyopen_wakeword.OpenWakeWord", _FakeOpenWakeWord):
+            model = available.load()
+
+        assert model.id == "okay_nabu_oww"
+
+    def test_oww_wake_word_is_set(self):
+        available = make_available_oww("okay_nabu_oww", "ok_nabu_v0.1.tflite")
+
+        with patch("pyopen_wakeword.OpenWakeWord", _FakeOpenWakeWord):
+            model = available.load()
+
+        assert model.wake_word == "Ok Nabu (OWW)"


### PR DESCRIPTION
# What does this implement/fix?

`AvailableWakeWord.load()` sets `wake_word` on a loaded openWakeWord model but never `id`, so the model keeps the `id` `pyopen_wakeword` derives from the `.tflite` filename.

Models are keyed by the manifest filename stem (`wake_word.py:40`, then `wake_word.py:154`), but the manifest's `"model"` field can name any file (`wake_word.py:53`), so the two are independent. Detection then filters on the derived value:

```python
wake_words = [ww for ww in state.wake_words.values() if ww.id in state.active_wake_words]  # __main__.py:681
```

When a manifest's name differs from the model file it points at, the model loads, is stored, is reported to Home Assistant as active, and is silently omitted from detection. No warning on any path. It presents as a wake word that simply never triggers.

Reproduced with pyopen-wakeword 1.1.0: a manifest `okay_nabu_oww.json` pointing at `ok_nabu_v0.1.tflite` loads a model whose `.id` is `'ok_nabu_v0.1'`, so filtering against `active_wake_words={'okay_nabu_oww'}` leaves zero models to evaluate. With `id` set from the manifest, it is one.

The bundled models are unaffected, because each manifest stem happens to match its `.tflite` stem. It bites as soon as a manifest is named differently, which is the natural thing to do when disambiguating an openWakeWord model from a same-named micro one.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `./script/lint` passes.
- [x] `./script/tests` passes, and tests have been added/updated under `tests/` where applicable.